### PR TITLE
fix: FAB position above BottomNav in PurchasesPage

### DIFF
--- a/frontend/src/features/purchases/pages/PurchasesPage.tsx
+++ b/frontend/src/features/purchases/pages/PurchasesPage.tsx
@@ -163,8 +163,8 @@ export function PurchasesPage() {
           aria-label={t('purchases.addPurchase')}
           sx={{
             position: 'fixed',
-            bottom: { xs: 10, sm: 2 },
-            right: 2,
+            bottom: { xs: 'calc(env(safe-area-inset-bottom) + 80px)', sm: 24 },
+            right: 16,
             minWidth: 56,
             minHeight: 56,
           }}


### PR DESCRIPTION
## Problem
FAB (quick add button) in PurchasesPage was hidden behind the BottomNavigation bar on iPhone due to `bottom: { xs: 10, sm: 2 }` — same bug as the pages fixed in PR #18.

## Fix
Same fix applied: `bottom: calc(env(safe-area-inset-bottom) + 80px)` on mobile, `right: 16px`.

## Tests
669/669 passing ✓