### PR TITLE
fix: add Purchases to bottom navigation

### DIFF
--- a/frontend/src/components/BottomNavigation.tsx
+++ b/frontend/src/components/BottomNavigation.tsx
@@ -4,7 +4,8 @@ import {
   HomeWork as CoopsIcon,
   Assignment as DailyRecordsIcon,
   BarChart as StatisticsIcon,
-  Settings as SettingsIcon
+  Settings as SettingsIcon,
+  ShoppingCart as PurchasesIcon,
 } from '@mui/icons-material';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
@@ -18,6 +19,7 @@ export function BottomNavigation() {
     if (location.pathname.startsWith('/coops')) return 'coops';
     if (location.pathname.startsWith('/daily-records')) return 'daily-records';
     if (location.pathname.startsWith('/statistics')) return 'statistics';
+    if (location.pathname.startsWith('/purchases')) return 'purchases';
     if (location.pathname.startsWith('/settings')) return 'settings';
     return 'dashboard';
   };
@@ -35,6 +37,9 @@ export function BottomNavigation() {
         break;
       case 'statistics':
         navigate('/statistics');
+        break;
+      case 'purchases':
+        navigate('/purchases');
         break;
       case 'settings':
         navigate('/settings');
@@ -93,6 +98,11 @@ export function BottomNavigation() {
           label={t('navigation.statistics')}
           value="statistics"
           icon={<StatisticsIcon />}
+        />
+        <BottomNavigationAction
+          label={t('navigation.purchases')}
+          value="purchases"
+          icon={<PurchasesIcon />}
         />
         <BottomNavigationAction
           label={t('navigation.settings')}

--- a/frontend/src/components/__tests__/BottomNavigation.test.tsx
+++ b/frontend/src/components/__tests__/BottomNavigation.test.tsx
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { BottomNavigation } from '../BottomNavigation';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        'navigation.dashboard': 'Dashboard',
+        'navigation.coops': 'Coops',
+        'navigation.dailyRecords': 'Daily Records',
+        'navigation.statistics': 'Statistics',
+        'navigation.purchases': 'Purchases',
+        'navigation.settings': 'Settings',
+      };
+      return translations[key] ?? key;
+    },
+  }),
+}));
+
+function renderWithRouter(initialPath: string) {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <BottomNavigation />
+    </MemoryRouter>
+  );
+}
+
+describe('BottomNavigation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('renders all navigation items', () => {
+    it('shows all six navigation items', () => {
+      renderWithRouter('/dashboard');
+      expect(screen.getByText('Dashboard')).toBeInTheDocument();
+      expect(screen.getByText('Coops')).toBeInTheDocument();
+      expect(screen.getByText('Daily Records')).toBeInTheDocument();
+      expect(screen.getByText('Statistics')).toBeInTheDocument();
+      expect(screen.getByText('Purchases')).toBeInTheDocument();
+      expect(screen.getByText('Settings')).toBeInTheDocument();
+    });
+  });
+
+  describe('active tab detection', () => {
+    it('activates dashboard tab on /dashboard', () => {
+      renderWithRouter('/dashboard');
+      const dashboardButton = screen.getByRole('button', { name: /dashboard/i });
+      expect(dashboardButton).toHaveClass('Mui-selected');
+    });
+
+    it('activates purchases tab on /purchases', () => {
+      renderWithRouter('/purchases');
+      const purchasesButton = screen.getByRole('button', { name: /purchases/i });
+      expect(purchasesButton).toHaveClass('Mui-selected');
+    });
+
+    it('activates purchases tab on /purchases/new', () => {
+      renderWithRouter('/purchases/new');
+      const purchasesButton = screen.getByRole('button', { name: /purchases/i });
+      expect(purchasesButton).toHaveClass('Mui-selected');
+    });
+
+    it('does not activate purchases tab on /dashboard', () => {
+      renderWithRouter('/dashboard');
+      const purchasesButton = screen.getByRole('button', { name: /purchases/i });
+      expect(purchasesButton).not.toHaveClass('Mui-selected');
+    });
+
+    it('activates coops tab on /coops', () => {
+      renderWithRouter('/coops');
+      const coopsButton = screen.getByRole('button', { name: /coops/i });
+      expect(coopsButton).toHaveClass('Mui-selected');
+    });
+
+    it('activates settings tab on /settings', () => {
+      renderWithRouter('/settings');
+      const settingsButton = screen.getByRole('button', { name: /settings/i });
+      expect(settingsButton).toHaveClass('Mui-selected');
+    });
+  });
+
+  describe('navigation on click', () => {
+    it('navigates to /purchases when clicking Purchases', async () => {
+      const user = userEvent.setup();
+      renderWithRouter('/dashboard');
+      await user.click(screen.getByRole('button', { name: /purchases/i }));
+      expect(mockNavigate).toHaveBeenCalledWith('/purchases');
+    });
+
+    it('navigates to /dashboard when clicking Dashboard', async () => {
+      const user = userEvent.setup();
+      renderWithRouter('/purchases');
+      await user.click(screen.getByRole('button', { name: /dashboard/i }));
+      expect(mockNavigate).toHaveBeenCalledWith('/dashboard');
+    });
+
+    it('navigates to /settings when clicking Settings', async () => {
+      const user = userEvent.setup();
+      renderWithRouter('/dashboard');
+      await user.click(screen.getByRole('button', { name: /settings/i }));
+      expect(mockNavigate).toHaveBeenCalledWith('/settings');
+    });
+  });
+});


### PR DESCRIPTION
Fixes #20

## Problem
The Purchases page existed (route `/purchases` in `App.tsx`, translation key `navigation.purchases` present) but there was no entry in the bottom navigation bar. Navigating to `/purchases` also incorrectly highlighted the Dashboard tab.

## Changes
- `BottomNavigation.tsx`: added `ShoppingCart` icon import, `/purchases` path detection in `getCurrentTab()`, `purchases` case in `handleChange()`, and a `<BottomNavigationAction>` for Purchases between Statistics and Settings
- `BottomNavigation.test.tsx`: new test file covering all 6 nav items rendered, active tab detection for `/purchases` (including sub-paths), and click navigation to `/purchases`

## Tests
All 679 existing tests pass + 10 new tests added.