### PR TITLE
fix: add Quick Add FAB to Daily Records page (#21)

### DIFF
--- a/frontend/src/pages/DailyRecordsListPage.tsx
+++ b/frontend/src/pages/DailyRecordsListPage.tsx
@@ -12,18 +12,23 @@ import {
   Chip,
   Card,
   CardContent,
+  Fab,
+  Tooltip,
 } from '@mui/material';
 import {
   Egg as EggIcon,
   FilterList as FilterIcon,
   Clear as ClearIcon,
+  Add as AddIcon,
 } from '@mui/icons-material';
 import { useTranslation } from 'react-i18next';
 import { format, subDays } from 'date-fns';
 import { useDailyRecords } from '../features/dailyRecords/hooks/useDailyRecords';
 import { useCoops } from '../features/coops/hooks/useCoops';
+import { useAllFlocks } from '../features/flocks/hooks/useAllFlocks';
 import { DailyRecordCard } from '../features/dailyRecords/components/DailyRecordCard';
 import { EditDailyRecordModal } from '../features/dailyRecords/components/EditDailyRecordModal';
+import { QuickAddModal } from '../features/dailyRecords/components/QuickAddModal';
 import { IllustratedEmptyState, DailyRecordCardSkeleton } from '../shared/components';
 import type { GetDailyRecordsParams, DailyRecordDto } from '../features/dailyRecords/api/dailyRecordsApi';
 
@@ -33,8 +38,11 @@ export function DailyRecordsListPage() {
   const [editingRecord, setEditingRecord] = useState<DailyRecordDto | null>(null);
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
 
+  const [isQuickAddOpen, setIsQuickAddOpen] = useState(false);
+
   const { isLoading: isLoadingCoops } = useCoops();
   const { data: dailyRecords, isLoading: isLoadingRecords } = useDailyRecords(filters);
+  const { data: flocks = [] } = useAllFlocks();
 
   // Create a map of flock IDs to display labels (flockName + coopName) for filter dropdown
   const flockMap = useMemo(() => {
@@ -294,6 +302,32 @@ export function DailyRecordsListPage() {
           </Box>
         </>
       )}
+
+      {/* Floating Action Button - Add Daily Record */}
+      <Tooltip title={t('dailyRecords.addRecord')} placement="left">
+        <span>
+          <Fab
+            color="primary"
+            aria-label={t('dailyRecords.addRecord')}
+            onClick={() => setIsQuickAddOpen(true)}
+            disabled={flocks.length === 0}
+            sx={{
+              position: 'fixed',
+              bottom: { xs: 'calc(env(safe-area-inset-bottom) + 80px)', sm: 24 },
+              right: 16,
+            }}
+          >
+            <AddIcon />
+          </Fab>
+        </span>
+      </Tooltip>
+
+      {/* Quick Add Modal */}
+      <QuickAddModal
+        open={isQuickAddOpen}
+        onClose={() => setIsQuickAddOpen(false)}
+        flocks={flocks}
+      />
 
       {/* Edit Modal */}
       <EditDailyRecordModal

--- a/frontend/src/pages/__tests__/DailyRecordsListPage.test.tsx
+++ b/frontend/src/pages/__tests__/DailyRecordsListPage.test.tsx
@@ -1,0 +1,244 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BrowserRouter } from 'react-router-dom';
+import { DailyRecordsListPage } from '../DailyRecordsListPage';
+import type { DailyRecordDto } from '../../features/dailyRecords/api/dailyRecordsApi';
+import type { FlockForQuickAdd } from '../../features/flocks/hooks/useAllFlocks';
+
+// Mock hooks
+const mockUseDailyRecords = vi.fn();
+const mockUseCoops = vi.fn();
+const mockUseAllFlocks = vi.fn();
+
+vi.mock('../../features/dailyRecords/hooks/useDailyRecords', () => ({
+  useDailyRecords: () => mockUseDailyRecords(),
+}));
+
+vi.mock('../../features/coops/hooks/useCoops', () => ({
+  useCoops: () => mockUseCoops(),
+}));
+
+vi.mock('../../features/flocks/hooks/useAllFlocks', () => ({
+  useAllFlocks: () => mockUseAllFlocks(),
+}));
+
+// Mock child components
+vi.mock('../../features/dailyRecords/components/DailyRecordCard', () => ({
+  DailyRecordCard: ({ record }: { record: DailyRecordDto }) => (
+    <div data-testid="daily-record-card">{record.flockName}</div>
+  ),
+}));
+
+vi.mock('../../features/dailyRecords/components/EditDailyRecordModal', () => ({
+  EditDailyRecordModal: ({ open, onClose }: { open: boolean; onClose: () => void }) =>
+    open ? (
+      <div data-testid="edit-record-modal">
+        <button onClick={onClose}>Close Edit</button>
+      </div>
+    ) : null,
+}));
+
+vi.mock('../../features/dailyRecords/components/QuickAddModal', () => ({
+  QuickAddModal: ({
+    open,
+    onClose,
+  }: {
+    open: boolean;
+    onClose: () => void;
+    flocks: FlockForQuickAdd[];
+  }) =>
+    open ? (
+      <div data-testid="quick-add-modal">
+        <button onClick={onClose}>Close Quick Add</button>
+      </div>
+    ) : null,
+}));
+
+vi.mock('../../shared/components', () => ({
+  IllustratedEmptyState: ({ title }: { title: string }) => (
+    <div data-testid="empty-state">{title}</div>
+  ),
+  DailyRecordCardSkeleton: () => <div data-testid="skeleton" />,
+}));
+
+// Mock react-i18next
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, unknown>) => {
+      const translations: Record<string, string> = {
+        'dailyRecords.title': 'Daily Records',
+        'dailyRecords.addRecord': 'Add Record',
+        'dailyRecords.flock': 'Flock',
+        'dailyRecords.clearFilters': 'Clear filters',
+        'dailyRecords.recordsCount': `${params?.count ?? 0} records`,
+        'dailyRecords.filters.today': 'Today',
+        'dailyRecords.filters.lastWeek': 'Last week',
+        'dailyRecords.filters.lastMonth': 'Last month',
+        'dailyRecords.filters.startDate': 'Start date',
+        'dailyRecords.filters.endDate': 'End date',
+        'dailyRecords.emptyState.title': 'No records yet',
+        'dailyRecords.emptyState.noRecords': 'No records found',
+        'dailyRecords.emptyState.noRecordsFiltered': 'No records match filters',
+        'common.filter': 'Filter',
+        'common.all': 'All',
+      };
+      return translations[key] ?? key;
+    },
+  }),
+}));
+
+const mockFlocks: FlockForQuickAdd[] = [
+  { id: 'flock-1', identifier: 'Flock A', coopName: 'Main Coop' },
+  { id: 'flock-2', identifier: 'Flock B', coopName: 'Secondary Coop' },
+];
+
+const mockRecords: DailyRecordDto[] = [
+  {
+    id: 'rec-1',
+    tenantId: 'tenant-1',
+    flockId: 'flock-1',
+    flockName: 'Flock A',
+    flockCoopName: 'Main Coop',
+    recordDate: '2024-01-15',
+    eggCount: 10,
+    createdAt: '2024-01-15T10:00:00Z',
+    updatedAt: '2024-01-15T10:00:00Z',
+  },
+];
+
+describe('DailyRecordsListPage', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    vi.clearAllMocks();
+
+    // Default: data loaded, no error
+    mockUseCoops.mockReturnValue({ isLoading: false });
+    mockUseDailyRecords.mockReturnValue({ data: [], isLoading: false });
+    mockUseAllFlocks.mockReturnValue({ data: [] });
+  });
+
+  const renderPage = () =>
+    render(
+      <BrowserRouter>
+        <QueryClientProvider client={queryClient}>
+          <DailyRecordsListPage />
+        </QueryClientProvider>
+      </BrowserRouter>
+    );
+
+  describe('FAB rendering', () => {
+    it('renders Add Record FAB when flocks exist', () => {
+      mockUseAllFlocks.mockReturnValue({ data: mockFlocks });
+
+      renderPage();
+
+      expect(screen.getByRole('button', { name: 'Add Record' })).toBeInTheDocument();
+    });
+
+    it('renders FAB even when no flocks exist (disabled)', () => {
+      mockUseAllFlocks.mockReturnValue({ data: [] });
+
+      renderPage();
+
+      expect(screen.getByRole('button', { name: 'Add Record' })).toBeInTheDocument();
+    });
+
+    it('FAB is disabled when no flocks exist', () => {
+      mockUseAllFlocks.mockReturnValue({ data: [] });
+
+      renderPage();
+
+      expect(screen.getByRole('button', { name: 'Add Record' })).toBeDisabled();
+    });
+
+    it('FAB is enabled when flocks exist', () => {
+      mockUseAllFlocks.mockReturnValue({ data: mockFlocks });
+
+      renderPage();
+
+      expect(screen.getByRole('button', { name: 'Add Record' })).not.toBeDisabled();
+    });
+  });
+
+  describe('QuickAddModal', () => {
+    it('QuickAddModal is not shown by default', () => {
+      mockUseAllFlocks.mockReturnValue({ data: mockFlocks });
+
+      renderPage();
+
+      expect(screen.queryByTestId('quick-add-modal')).not.toBeInTheDocument();
+    });
+
+    it('clicking FAB opens QuickAddModal', async () => {
+      const user = userEvent.setup();
+      mockUseAllFlocks.mockReturnValue({ data: mockFlocks });
+
+      renderPage();
+
+      await user.click(screen.getByRole('button', { name: 'Add Record' }));
+
+      expect(screen.getByTestId('quick-add-modal')).toBeInTheDocument();
+    });
+
+    it('QuickAddModal closes when onClose is called', async () => {
+      const user = userEvent.setup();
+      mockUseAllFlocks.mockReturnValue({ data: mockFlocks });
+
+      renderPage();
+
+      await user.click(screen.getByRole('button', { name: 'Add Record' }));
+      expect(screen.getByTestId('quick-add-modal')).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: 'Close Quick Add' }));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('quick-add-modal')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Records list', () => {
+    it('renders records when data is available', () => {
+      mockUseDailyRecords.mockReturnValue({ data: mockRecords, isLoading: false });
+      mockUseAllFlocks.mockReturnValue({ data: mockFlocks });
+
+      renderPage();
+
+      expect(screen.getByTestId('daily-record-card')).toBeInTheDocument();
+    });
+
+    it('shows empty state when no records', () => {
+      mockUseDailyRecords.mockReturnValue({ data: [], isLoading: false });
+
+      renderPage();
+
+      expect(screen.getByTestId('empty-state')).toBeInTheDocument();
+    });
+
+    it('shows skeletons while loading', () => {
+      mockUseCoops.mockReturnValue({ isLoading: true });
+      mockUseDailyRecords.mockReturnValue({ data: undefined, isLoading: true });
+
+      renderPage();
+
+      expect(screen.getAllByTestId('skeleton').length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Page structure', () => {
+    it('renders page title', () => {
+      renderPage();
+
+      expect(screen.getByRole('heading', { name: 'Daily Records' })).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Problem

The Daily Records page had no button to add a new record. The only way to add a record was via the FAB on the Dashboard page.

Fixes #21

## Solution

- Added a floating action button (FAB) to `DailyRecordsListPage`
- Clicking the FAB opens the existing `QuickAddModal` component
- FAB is disabled when no flocks exist (same behaviour as Dashboard)
- Matches the exact same pattern used on `DashboardPage`

## Tests

- Added 11 unit tests covering FAB rendering, enabled/disabled state, modal open/close