### PR TITLE
fix(i18n): rename Identifier to Name in flock form and detail

### DIFF
--- a/frontend/src/locales/cs/translation.json
+++ b/frontend/src/locales/cs/translation.json
@@ -136,7 +136,7 @@
     "deleteFlock": "Smazat hejno",
     "archiveFlock": "Archivovat hejno",
     "flockName": "Název hejna",
-    "identifier": "Identifikátor",
+    "identifier": "Název",
     "hens": "Slepice",
     "roosters": "Kohouti",
     "chicks": "Kuřata",
@@ -155,7 +155,7 @@
     "flockCardAriaLabel": "Hejno {{identifier}} v kurníku {{coopName}}",
     "belongsToCoopAriaLabel": "Patří do kurníku {{coopName}}",
     "form": {
-      "identifier": "Identifikátor hejna",
+      "identifier": "Název hejna",
       "hatchDate": "Datum líhnutí",
       "hatchDateFuture": "Datum nemůže být v budoucnosti",
       "composition": "Složení hejna",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -136,7 +136,7 @@
     "deleteFlock": "Delete Flock",
     "archiveFlock": "Archive Flock",
     "flockName": "Flock Name",
-    "identifier": "Identifier",
+    "identifier": "Name",
     "hens": "Hens",
     "roosters": "Roosters",
     "chicks": "Chicks",
@@ -155,7 +155,7 @@
     "flockCardAriaLabel": "Flock {{identifier}} in coop {{coopName}}",
     "belongsToCoopAriaLabel": "Belongs to coop {{coopName}}",
     "form": {
-      "identifier": "Flock Identifier",
+      "identifier": "Flock Name",
       "hatchDate": "Hatch Date",
       "hatchDateFuture": "Date cannot be in the future",
       "composition": "Flock Composition",


### PR DESCRIPTION
The flock create/edit form label and FlockDetailPage used the technical term "Identifier" ("Identifikátor" in Czech), which is confusing for end users.

Updated translations:
- `flocks.form.identifier`: "Flock Identifier" → "Flock Name"
- `flocks.identifier`: "Identifier" → "Name"
- Czech equivalents updated accordingly

Closes #24