### PR TITLE
fix(#26): add tooltip to disabled Mature Chicks button

### DIFF
--- a/frontend/src/locales/cs/translation.json
+++ b/frontend/src/locales/cs/translation.json
@@ -175,6 +175,8 @@
       "sumError": "Součet slepic a kohoutů musí být {{count}}",
       "confirm": "Potvrdit dospění",
       "action": "Dospět kuřata",
+      "disabledNoChicks": "Přidejte kuřata do hejna, abyste mohli použít tuto funkci",
+      "disabledInactive": "Nelze provést u archivovaného hejna",
       "success": "Kuřata úspěšně dospěla",
       "error": "Nepodařilo se provést dospění kuřat"
     },

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -175,6 +175,8 @@
       "sumError": "Sum of hens and roosters must equal {{count}}",
       "confirm": "Confirm Maturation",
       "action": "Mature Chicks",
+      "disabledNoChicks": "Add chicks to your flock to use this feature",
+      "disabledInactive": "Cannot perform this action on an archived flock",
       "success": "Chicks matured successfully",
       "error": "Failed to mature chicks"
     },

--- a/frontend/src/pages/FlockDetailPage.tsx
+++ b/frontend/src/pages/FlockDetailPage.tsx
@@ -12,6 +12,7 @@ import {
   Grid,
   IconButton,
   Divider,
+  Tooltip,
 } from '@mui/material';
 import {
   ArrowBack as ArrowBackIcon,
@@ -296,15 +297,30 @@ export function FlockDetailPage() {
             >
               {t('flocks.viewHistory')}
             </Button>
-            <Button
-              variant="outlined"
-              startIcon={<PetsIcon />}
-              onClick={() => setIsMatureChicksModalOpen(true)}
-              disabled={!flock.isActive || flock.currentChicks === 0}
-              sx={{ width: { xs: '100%', md: 'auto' } }}
+            <Tooltip
+              title={
+                !flock.isActive
+                  ? t('flocks.matureChicks.disabledInactive')
+                  : flock.currentChicks === 0
+                    ? t('flocks.matureChicks.disabledNoChicks')
+                    : ''
+              }
+              disableHoverListener={flock.isActive && flock.currentChicks > 0}
+              disableFocusListener={flock.isActive && flock.currentChicks > 0}
+              disableTouchListener={flock.isActive && flock.currentChicks > 0}
             >
-              {t('flocks.matureChicks.action')}
-            </Button>
+              <span>
+                <Button
+                  variant="outlined"
+                  startIcon={<PetsIcon />}
+                  onClick={() => setIsMatureChicksModalOpen(true)}
+                  disabled={!flock.isActive || flock.currentChicks === 0}
+                  sx={{ width: { xs: '100%', md: 'auto' } }}
+                >
+                  {t('flocks.matureChicks.action')}
+                </Button>
+              </span>
+            </Tooltip>
           </Stack>
         </Stack>
       </Paper>


### PR DESCRIPTION
Closes #26

When the "Mature Chicks" button is disabled, a tooltip now explains why:
- If flock has 0 chicks: "Add chicks to your flock to use this feature"
- If flock is archived: "Cannot perform this action on an archived flock"

Tooltip uses MUI `Tooltip` wrapped around a `span` (required for disabled buttons). Both CS and EN translations added.