### PR TITLE
fix(#28): show coop name as subtitle on Flocks page

### DIFF
--- a/frontend/src/pages/FlocksPage.tsx
+++ b/frontend/src/pages/FlocksPage.tsx
@@ -189,6 +189,11 @@ export default function FlocksPage() {
         <Typography variant="h4" component="h1" gutterBottom>
           {t('flocks.title')}
         </Typography>
+        {coop?.name && (
+          <Typography variant="subtitle1" color="text.secondary" sx={{ mt: -1, mb: 1 }}>
+            {coop.name}
+          </Typography>
+        )}
 
         {/* Filter toggle */}
         <Box sx={{ mb: 3, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>


### PR DESCRIPTION
Closes #28

Adds the coop name as a subtitle below the "Flocks" heading so users know which coop they are viewing.

The `coop` data was already being fetched via `useCoopDetail` but not displayed in the page title area.