### PR TITLE
fix(#29): use unambiguous locale-aware date format on chart X-axes

### DIFF
--- a/frontend/src/features/statistics/components/CostPerEggTrendChart.tsx
+++ b/frontend/src/features/statistics/components/CostPerEggTrendChart.tsx
@@ -64,11 +64,14 @@ function CostPerEggTrendTooltip({ active, payload }: CostPerEggTrendTooltipProps
 }
 
 export function CostPerEggTrendChart({ data }: CostPerEggTrendChartProps) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
 
-  // Format date for display
+  // Format date for display — unambiguous, locale-aware
   const formatDate = (dateString: string) => {
-    return dayjs(dateString).format('DD/MM');
+    const d = dayjs(dateString);
+    return i18n.language === 'cs'
+      ? d.format('D. M. YYYY')
+      : d.format('D MMM YYYY');
   };
 
   // Calculate trend (compare first and last values)

--- a/frontend/src/features/statistics/components/ProductionTrendChart.tsx
+++ b/frontend/src/features/statistics/components/ProductionTrendChart.tsx
@@ -61,11 +61,14 @@ function ProductionTrendTooltip({ active, payload }: ProductionTrendTooltipProps
 }
 
 export function ProductionTrendChart({ data }: ProductionTrendChartProps) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
 
-  // Format date for display
+  // Format date for display — unambiguous, locale-aware
   const formatDate = (dateString: string) => {
-    return dayjs(dateString).format('DD/MM');
+    const d = dayjs(dateString);
+    return i18n.language === 'cs'
+      ? d.format('D. M. YYYY')
+      : d.format('D MMM YYYY');
   };
 
   // Empty state


### PR DESCRIPTION
Closes #29

Replaces the ambiguous `DD/MM` format on chart X-axes with locale-aware formats:
- Czech (`cs`): `D. M. YYYY` (e.g. `3. 3. 2026`)
- English: `D MMM YYYY` (e.g. `3 Mar 2026`)

Year is now always visible so there is no ambiguity about which date a data point belongs to.