### PR TITLE
feat: add per-coop and per-flock filter to Statistics page

### DIFF
--- a/backend/src/Chickquita.Api/Endpoints/StatisticsEndpoints.cs
+++ b/backend/src/Chickquita.Api/Endpoints/StatisticsEndpoints.cs
@@ -66,11 +66,15 @@ public static class StatisticsEndpoints
     /// <param name="mediator">The mediator instance for dispatching the query.</param>
     /// <param name="startDate">Start date (YYYY-MM-DD format).</param>
     /// <param name="endDate">End date (YYYY-MM-DD format).</param>
+    /// <param name="coopId">Optional coop ID (GUID) to filter statistics to a specific coop.</param>
+    /// <param name="flockId">Optional flock ID (GUID) to filter statistics to a specific flock.</param>
     /// <returns>Detailed statistics DTO.</returns>
     private static async Task<IResult> GetStatistics(
         [FromServices] IMediator mediator,
         [FromQuery] string startDate,
-        [FromQuery] string endDate)
+        [FromQuery] string endDate,
+        [FromQuery] string? coopId = null,
+        [FromQuery] string? flockId = null)
     {
         // Parse date strings to DateOnly
         if (!DateOnly.TryParse(startDate, out var parsedStartDate))
@@ -83,10 +87,32 @@ public static class StatisticsEndpoints
             return Results.BadRequest(new { error = "Invalid endDate format. Use YYYY-MM-DD." });
         }
 
+        Guid? parsedCoopId = null;
+        if (coopId != null && !Guid.TryParse(coopId, out var tempCoopId))
+        {
+            return Results.BadRequest(new { error = "Invalid coopId format. Use a valid GUID." });
+        }
+        else if (coopId != null)
+        {
+            parsedCoopId = Guid.Parse(coopId);
+        }
+
+        Guid? parsedFlockId = null;
+        if (flockId != null && !Guid.TryParse(flockId, out var tempFlockId))
+        {
+            return Results.BadRequest(new { error = "Invalid flockId format. Use a valid GUID." });
+        }
+        else if (flockId != null)
+        {
+            parsedFlockId = Guid.Parse(flockId);
+        }
+
         var query = new GetStatisticsQuery
         {
             StartDate = parsedStartDate,
-            EndDate = parsedEndDate
+            EndDate = parsedEndDate,
+            CoopId = parsedCoopId,
+            FlockId = parsedFlockId
         };
 
         var result = await mediator.Send(query);

--- a/backend/src/Chickquita.Application/Features/Statistics/Queries/GetStatisticsQuery.cs
+++ b/backend/src/Chickquita.Application/Features/Statistics/Queries/GetStatisticsQuery.cs
@@ -19,4 +19,14 @@ public sealed record GetStatisticsQuery : IRequest<Result<StatisticsDto>>
     /// End date for the statistics period (inclusive).
     /// </summary>
     public required DateOnly EndDate { get; init; }
+
+    /// <summary>
+    /// Optional coop ID to filter statistics to a specific coop.
+    /// </summary>
+    public Guid? CoopId { get; init; }
+
+    /// <summary>
+    /// Optional flock ID to filter statistics to a specific flock.
+    /// </summary>
+    public Guid? FlockId { get; init; }
 }

--- a/backend/src/Chickquita.Application/Features/Statistics/Queries/GetStatisticsQueryHandler.cs
+++ b/backend/src/Chickquita.Application/Features/Statistics/Queries/GetStatisticsQueryHandler.cs
@@ -67,7 +67,7 @@ public sealed class GetStatisticsQueryHandler : IRequestHandler<GetStatisticsQue
             }
 
             // Retrieve statistics (tenant isolation is handled by RLS and repository)
-            var stats = await _statisticsRepository.GetStatisticsAsync(request.StartDate, request.EndDate);
+            var stats = await _statisticsRepository.GetStatisticsAsync(request.StartDate, request.EndDate, request.CoopId, request.FlockId);
 
             _logger.LogInformation(
                 "Retrieved statistics for tenant: {TenantId}, Period: {StartDate} to {EndDate}, Total Eggs: {TotalEggs}, Total Cost: {TotalCost}",

--- a/backend/src/Chickquita.Application/Interfaces/IStatisticsRepository.cs
+++ b/backend/src/Chickquita.Application/Interfaces/IStatisticsRepository.cs
@@ -21,5 +21,5 @@ public interface IStatisticsRepository
     /// <param name="startDate">Start date (inclusive)</param>
     /// <param name="endDate">End date (inclusive)</param>
     /// <returns>Detailed statistics DTO</returns>
-    Task<StatisticsDto> GetStatisticsAsync(DateOnly startDate, DateOnly endDate);
+    Task<StatisticsDto> GetStatisticsAsync(DateOnly startDate, DateOnly endDate, Guid? coopId = null, Guid? flockId = null);
 }

--- a/backend/src/Chickquita.Infrastructure/Repositories/StatisticsRepository.cs
+++ b/backend/src/Chickquita.Infrastructure/Repositories/StatisticsRepository.cs
@@ -93,19 +93,19 @@ public class StatisticsRepository : IStatisticsRepository
     /// Includes cost breakdown, production trends, cost per egg trends, and flock productivity.
     /// Tenant isolation is enforced by Row-Level Security (RLS) at the database level.
     /// </summary>
-    public async Task<StatisticsDto> GetStatisticsAsync(DateOnly startDate, DateOnly endDate)
+    public async Task<StatisticsDto> GetStatisticsAsync(DateOnly startDate, DateOnly endDate, Guid? coopId = null, Guid? flockId = null)
     {
         // 1. Cost Breakdown by Purchase Type
-        var costBreakdown = await GetCostBreakdownAsync(startDate, endDate);
+        var costBreakdown = await GetCostBreakdownAsync(startDate, endDate, coopId);
 
         // 2. Production Trend (daily eggs)
-        var productionTrend = await GetProductionTrendAsync(startDate, endDate);
+        var productionTrend = await GetProductionTrendAsync(startDate, endDate, coopId, flockId);
 
         // 3. Cost Per Egg Trend (cumulative)
-        var costPerEggTrend = await GetCostPerEggTrendAsync(startDate, endDate);
+        var costPerEggTrend = await GetCostPerEggTrendAsync(startDate, endDate, coopId, flockId);
 
         // 4. Flock Productivity Comparison
-        var flockProductivity = await GetFlockProductivityAsync(startDate, endDate);
+        var flockProductivity = await GetFlockProductivityAsync(startDate, endDate, coopId, flockId);
 
         // 5. Summary Statistics
         var totalEggs = productionTrend.Sum(p => p.Eggs);
@@ -130,13 +130,14 @@ public class StatisticsRepository : IStatisticsRepository
         };
     }
 
-    private async Task<List<CostBreakdownItemDto>> GetCostBreakdownAsync(DateOnly startDate, DateOnly endDate)
+    private async Task<List<CostBreakdownItemDto>> GetCostBreakdownAsync(DateOnly startDate, DateOnly endDate, Guid? coopId = null)
     {
         var startDateTime = DateTime.SpecifyKind(startDate.ToDateTime(TimeOnly.MinValue), DateTimeKind.Utc);
         var endDateTime = DateTime.SpecifyKind(endDate.ToDateTime(TimeOnly.MaxValue), DateTimeKind.Utc);
 
         var purchases = await _context.Purchases
             .Where(p => p.PurchaseDate >= startDateTime && p.PurchaseDate <= endDateTime)
+            .Where(p => coopId == null || p.CoopId == coopId)
             .GroupBy(p => p.Type)
             .Select(g => new
             {
@@ -155,13 +156,15 @@ public class StatisticsRepository : IStatisticsRepository
         }).ToList();
     }
 
-    private async Task<List<ProductionTrendItemDto>> GetProductionTrendAsync(DateOnly startDate, DateOnly endDate)
+    private async Task<List<ProductionTrendItemDto>> GetProductionTrendAsync(DateOnly startDate, DateOnly endDate, Guid? coopId = null, Guid? flockId = null)
     {
         var startDateTime = DateTime.SpecifyKind(startDate.ToDateTime(TimeOnly.MinValue), DateTimeKind.Utc);
         var endDateTime = DateTime.SpecifyKind(endDate.ToDateTime(TimeOnly.MaxValue), DateTimeKind.Utc);
 
         var groups = await _context.DailyRecords
             .Where(dr => dr.RecordDate >= startDateTime && dr.RecordDate <= endDateTime)
+            .Where(dr => flockId == null || dr.FlockId == flockId)
+            .Where(dr => coopId == null || dr.Flock!.CoopId == coopId)
             .GroupBy(dr => dr.RecordDate)
             .Select(g => new { Date = g.Key, Eggs = g.Sum(dr => dr.EggCount) })
             .OrderBy(g => g.Date)
@@ -174,7 +177,7 @@ public class StatisticsRepository : IStatisticsRepository
         }).ToList();
     }
 
-    private async Task<List<CostPerEggTrendItemDto>> GetCostPerEggTrendAsync(DateOnly startDate, DateOnly endDate)
+    private async Task<List<CostPerEggTrendItemDto>> GetCostPerEggTrendAsync(DateOnly startDate, DateOnly endDate, Guid? coopId = null, Guid? flockId = null)
     {
         var startDateTime = DateTime.SpecifyKind(startDate.ToDateTime(TimeOnly.MinValue), DateTimeKind.Utc);
         var endDateTime = DateTime.SpecifyKind(endDate.ToDateTime(TimeOnly.MaxValue), DateTimeKind.Utc);
@@ -182,6 +185,8 @@ public class StatisticsRepository : IStatisticsRepository
         // Get cumulative costs and eggs by date
         var dailyRecords = await _context.DailyRecords
             .Where(dr => dr.RecordDate >= startDateTime && dr.RecordDate <= endDateTime)
+            .Where(dr => flockId == null || dr.FlockId == flockId)
+            .Where(dr => coopId == null || dr.Flock!.CoopId == coopId)
             .GroupBy(dr => dr.RecordDate)
             .Select(g => new
             {
@@ -193,6 +198,7 @@ public class StatisticsRepository : IStatisticsRepository
 
         var purchases = await _context.Purchases
             .Where(p => p.PurchaseDate >= startDateTime && p.PurchaseDate <= endDateTime)
+            .Where(p => coopId == null || p.CoopId == coopId)
             .GroupBy(p => p.PurchaseDate)
             .Select(g => new
             {
@@ -230,13 +236,15 @@ public class StatisticsRepository : IStatisticsRepository
         return result;
     }
 
-    private async Task<List<FlockProductivityItemDto>> GetFlockProductivityAsync(DateOnly startDate, DateOnly endDate)
+    private async Task<List<FlockProductivityItemDto>> GetFlockProductivityAsync(DateOnly startDate, DateOnly endDate, Guid? coopId = null, Guid? flockId = null)
     {
         var startDateTime = DateTime.SpecifyKind(startDate.ToDateTime(TimeOnly.MinValue), DateTimeKind.Utc);
         var endDateTime = DateTime.SpecifyKind(endDate.ToDateTime(TimeOnly.MaxValue), DateTimeKind.Utc);
 
         var flockStats = await _context.DailyRecords
             .Where(dr => dr.RecordDate >= startDateTime && dr.RecordDate <= endDateTime)
+            .Where(dr => flockId == null || dr.FlockId == flockId)
+            .Where(dr => coopId == null || dr.Flock!.CoopId == coopId)
             .Include(dr => dr.Flock)
             .GroupBy(dr => new { dr.FlockId, dr.Flock!.Identifier })
             .Select(g => new

--- a/frontend/src/features/statistics/api/statisticsApi.ts
+++ b/frontend/src/features/statistics/api/statisticsApi.ts
@@ -11,9 +11,9 @@ import type { StatisticsDto } from '../types';
  * Fetch statistics for a given date range
  */
 export const statisticsApi = {
-  getStatistics: async (startDate: string, endDate: string): Promise<StatisticsDto> => {
+  getStatistics: async (startDate: string, endDate: string, coopId?: string, flockId?: string): Promise<StatisticsDto> => {
     const response = await apiClient.get<StatisticsDto>('/statistics', {
-      params: { startDate, endDate },
+      params: { startDate, endDate, ...(coopId && { coopId }), ...(flockId && { flockId }) },
     });
     return response.data;
   },

--- a/frontend/src/features/statistics/hooks/useStatistics.ts
+++ b/frontend/src/features/statistics/hooks/useStatistics.ts
@@ -11,10 +11,10 @@ import type { StatisticsDto } from '../types';
 /**
  * Fetch statistics for a given date range
  */
-export function useStatistics(startDate: string, endDate: string) {
+export function useStatistics(startDate: string, endDate: string, coopId?: string, flockId?: string) {
   return useQuery<StatisticsDto>({
-    queryKey: ['statistics', startDate, endDate],
-    queryFn: () => statisticsApi.getStatistics(startDate, endDate),
+    queryKey: ['statistics', startDate, endDate, coopId, flockId],
+    queryFn: () => statisticsApi.getStatistics(startDate, endDate, coopId, flockId),
     staleTime: 5 * 60 * 1000, // 5 minutes
     gcTime: 10 * 60 * 1000, // 10 minutes
   });

--- a/frontend/src/locales/cs/translation.json
+++ b/frontend/src/locales/cs/translation.json
@@ -467,6 +467,13 @@
     },
     "error": {
       "loadFailed": "Nepodařilo se načíst statistiky"
+    },
+    "filters": {
+      "title": "Filtry",
+      "coop": "Kurník",
+      "flock": "Hejno",
+      "allCoops": "Všechny kurníky",
+      "allFlocks": "Všechna hejna"
     }
   },
   "errors": {

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -465,6 +465,13 @@
     },
     "error": {
       "loadFailed": "Failed to load statistics"
+    },
+    "filters": {
+      "title": "Filters",
+      "coop": "Coop",
+      "flock": "Flock",
+      "allCoops": "All Coops",
+      "allFlocks": "All Flocks"
     }
   },
   "errors": {

--- a/frontend/src/pages/StatisticsPage.tsx
+++ b/frontend/src/pages/StatisticsPage.tsx
@@ -10,9 +10,14 @@ import {
   ToggleButton,
   Alert,
   Skeleton,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
 } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
+import FilterListIcon from '@mui/icons-material/FilterList';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
@@ -28,6 +33,8 @@ import { ProductionTrendChart } from '@/features/statistics/components/Productio
 import { CostPerEggTrendChart } from '@/features/statistics/components/CostPerEggTrendChart';
 import { FlockProductivityChart } from '@/features/statistics/components/FlockProductivityChart';
 import { useStatistics } from '@/features/statistics/hooks/useStatistics';
+import { useCoops } from '@/features/coops/hooks/useCoops';
+import { useFlocks } from '@/features/flocks/hooks/useFlocks';
 
 /**
  * Statistics Page Component
@@ -46,6 +53,8 @@ export default function StatisticsPage() {
   const [dateRange, setDateRange] = useState<'7' | '30' | '90' | 'custom'>('30');
   const [customStartDate, setCustomStartDate] = useState<Dayjs | null>(null);
   const [customEndDate, setCustomEndDate] = useState<Dayjs | null>(null);
+  const [selectedCoopId, setSelectedCoopId] = useState<string>('');
+  const [selectedFlockId, setSelectedFlockId] = useState<string>('');
 
   // Calculate date range based on selection
   const getDateRange = () => {
@@ -66,12 +75,24 @@ export default function StatisticsPage() {
   };
 
   const { startDate, endDate } = getDateRange();
-  const { data: stats, isLoading, error } = useStatistics(startDate, endDate);
+  const { data: coops } = useCoops();
+  const { data: flocks } = useFlocks(selectedCoopId, true);
+  const { data: stats, isLoading, error } = useStatistics(
+    startDate,
+    endDate,
+    selectedCoopId || undefined,
+    selectedFlockId || undefined,
+  );
 
   const handleDateRangeChange = (_event: React.MouseEvent<HTMLElement>, newRange: string | null) => {
     if (newRange !== null) {
       setDateRange(newRange as '7' | '30' | '90' | 'custom');
     }
+  };
+
+  const handleCoopChange = (coopId: string) => {
+    setSelectedCoopId(coopId);
+    setSelectedFlockId('');
   };
 
   return (
@@ -155,6 +176,59 @@ export default function StatisticsPage() {
                 </Box>
               )}
             </Box>
+            </CardContent>
+          </Card>
+
+          {/* Coop / Flock Filters */}
+          <Card elevation={1} sx={{ mb: 3 }}>
+            <CardContent sx={{ p: 2, '&:last-child': { pb: 2 } }}>
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  <FilterListIcon color="action" />
+                  <Typography variant="subtitle1" fontWeight={600}>
+                    {t('statistics.filters.title')}
+                  </Typography>
+                </Box>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    flexDirection: { xs: 'column', sm: 'row' },
+                    gap: 2,
+                  }}
+                >
+                  <FormControl fullWidth>
+                    <InputLabel>{t('statistics.filters.coop')}</InputLabel>
+                    <Select
+                      value={selectedCoopId}
+                      label={t('statistics.filters.coop')}
+                      onChange={(e) => handleCoopChange(e.target.value)}
+                    >
+                      <MenuItem value="">{t('statistics.filters.allCoops')}</MenuItem>
+                      {coops?.filter((c) => c.isActive).map((coop) => (
+                        <MenuItem key={coop.id} value={coop.id}>
+                          {coop.name}
+                        </MenuItem>
+                      ))}
+                    </Select>
+                  </FormControl>
+
+                  <FormControl fullWidth disabled={!selectedCoopId}>
+                    <InputLabel>{t('statistics.filters.flock')}</InputLabel>
+                    <Select
+                      value={selectedFlockId}
+                      label={t('statistics.filters.flock')}
+                      onChange={(e) => setSelectedFlockId(e.target.value)}
+                    >
+                      <MenuItem value="">{t('statistics.filters.allFlocks')}</MenuItem>
+                      {flocks?.map((flock) => (
+                        <MenuItem key={flock.id} value={flock.id}>
+                          {flock.identifier}
+                        </MenuItem>
+                      ))}
+                    </Select>
+                  </FormControl>
+                </Box>
+              </Box>
             </CardContent>
           </Card>
 


### PR DESCRIPTION
Fixes #30

## Changes

**Backend**
- `GetStatisticsQuery` extended with optional `CoopId` and `FlockId`
- `IStatisticsRepository.GetStatisticsAsync` updated to accept optional filter params
- `StatisticsRepository` filters all sub-queries (cost breakdown, production trend, cost/egg trend, flock productivity) by coop and/or flock using `WHERE x = null OR x = value` pattern
- `GET /statistics` endpoint exposes optional `coopId` and `flockId` query params with GUID validation

**Frontend**
- `statisticsApi.getStatistics` and `useStatistics` hook accept optional `coopId` / `flockId`
- `StatisticsPage` adds a Filters card with Coop and Flock Select dropdowns
- Selecting a coop resets flock selection and enables the Flock dropdown (scoped to that coop)
- i18n: added `statistics.filters` keys in both `en` and `cs`