### PR TITLE
fix: Merge Daily Records and Statistics into Records section with tabs

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,13 +3,12 @@ import { Routes, Route, Navigate, useNavigate } from 'react-router-dom'
 import SignUpPage from './pages/SignUpPage'
 import SignInPage from './pages/SignInPage'
 import DashboardPage from './pages/DashboardPage'
-import StatisticsPage from './pages/StatisticsPage'
 import CoopsPage from './pages/CoopsPage'
 import { CoopDetailPage } from './pages/CoopDetailPage'
 import FlocksPage from './pages/FlocksPage'
 import { FlockDetailPage } from './pages/FlockDetailPage'
 import { FlockHistoryPage } from './features/flocks/components/FlockHistoryPage'
-import { DailyRecordsListPage } from './pages/DailyRecordsListPage'
+import { RecordsPage } from './pages/RecordsPage'
 import { PurchasesPage } from './features/purchases/pages/PurchasesPage'
 import { SettingsPage } from './pages/SettingsPage'
 import NotFoundPage from './pages/NotFoundPage'
@@ -90,9 +89,13 @@ function App() {
           />
           <Route
             path="/statistics"
+            element={<Navigate to="/records/stats" replace />}
+          />
+          <Route
+            path="/records/*"
             element={
               <ProtectedRoute>
-                <StatisticsPage />
+                <RecordsPage />
               </ProtectedRoute>
             }
           />
@@ -138,11 +141,7 @@ function App() {
           />
           <Route
             path="/daily-records"
-            element={
-              <ProtectedRoute>
-                <DailyRecordsListPage />
-              </ProtectedRoute>
-            }
+            element={<Navigate to="/records/list" replace />}
           />
           <Route
             path="/purchases"

--- a/frontend/src/components/BottomNavigation.tsx
+++ b/frontend/src/components/BottomNavigation.tsx
@@ -2,8 +2,7 @@ import { BottomNavigation as MuiBottomNavigation, BottomNavigationAction, Paper 
 import {
   Dashboard as DashboardIcon,
   HomeWork as CoopsIcon,
-  Assignment as DailyRecordsIcon,
-  BarChart as StatisticsIcon,
+  Assignment as RecordsIcon,
   Settings as SettingsIcon,
   ShoppingCart as PurchasesIcon,
 } from '@mui/icons-material';
@@ -17,8 +16,9 @@ export function BottomNavigation() {
 
   const getCurrentTab = () => {
     if (location.pathname.startsWith('/coops')) return 'coops';
-    if (location.pathname.startsWith('/daily-records')) return 'daily-records';
-    if (location.pathname.startsWith('/statistics')) return 'statistics';
+    if (location.pathname.startsWith('/records')) return 'records';
+    if (location.pathname.startsWith('/daily-records')) return 'records';
+    if (location.pathname.startsWith('/statistics')) return 'records';
     if (location.pathname.startsWith('/purchases')) return 'purchases';
     if (location.pathname.startsWith('/settings')) return 'settings';
     return 'dashboard';
@@ -32,11 +32,8 @@ export function BottomNavigation() {
       case 'coops':
         navigate('/coops');
         break;
-      case 'daily-records':
-        navigate('/daily-records');
-        break;
-      case 'statistics':
-        navigate('/statistics');
+      case 'records':
+        navigate('/records/list');
         break;
       case 'purchases':
         navigate('/purchases');
@@ -90,14 +87,9 @@ export function BottomNavigation() {
           icon={<CoopsIcon />}
         />
         <BottomNavigationAction
-          label={t('navigation.dailyRecords')}
-          value="daily-records"
-          icon={<DailyRecordsIcon />}
-        />
-        <BottomNavigationAction
-          label={t('navigation.statistics')}
-          value="statistics"
-          icon={<StatisticsIcon />}
+          label={t('navigation.records')}
+          value="records"
+          icon={<RecordsIcon />}
         />
         <BottomNavigationAction
           label={t('navigation.purchases')}

--- a/frontend/src/components/__tests__/BottomNavigation.test.tsx
+++ b/frontend/src/components/__tests__/BottomNavigation.test.tsx
@@ -20,8 +20,7 @@ vi.mock('react-i18next', () => ({
       const translations: Record<string, string> = {
         'navigation.dashboard': 'Dashboard',
         'navigation.coops': 'Coops',
-        'navigation.dailyRecords': 'Daily Records',
-        'navigation.statistics': 'Statistics',
+        'navigation.records': 'Records',
         'navigation.purchases': 'Purchases',
         'navigation.settings': 'Settings',
       };
@@ -43,57 +42,83 @@ describe('BottomNavigation', () => {
     vi.clearAllMocks();
   });
 
-  describe('renders all navigation items', () => {
-    it('shows all six navigation items', () => {
+  describe('renders navigation items', () => {
+    it('shows five navigation items', () => {
       renderWithRouter('/dashboard');
       expect(screen.getByText('Dashboard')).toBeInTheDocument();
       expect(screen.getByText('Coops')).toBeInTheDocument();
-      expect(screen.getByText('Daily Records')).toBeInTheDocument();
-      expect(screen.getByText('Statistics')).toBeInTheDocument();
+      expect(screen.getByText('Records')).toBeInTheDocument();
       expect(screen.getByText('Purchases')).toBeInTheDocument();
       expect(screen.getByText('Settings')).toBeInTheDocument();
+    });
+
+    it('does not show separate Daily Records and Statistics items', () => {
+      renderWithRouter('/dashboard');
+      expect(screen.queryByText('Daily Records')).not.toBeInTheDocument();
+      expect(screen.queryByText('Statistics')).not.toBeInTheDocument();
     });
   });
 
   describe('active tab detection', () => {
     it('activates dashboard tab on /dashboard', () => {
       renderWithRouter('/dashboard');
-      const dashboardButton = screen.getByRole('button', { name: /dashboard/i });
-      expect(dashboardButton).toHaveClass('Mui-selected');
+      expect(screen.getByRole('button', { name: /dashboard/i })).toHaveClass('Mui-selected');
+    });
+
+    it('activates records tab on /records/list', () => {
+      renderWithRouter('/records/list');
+      expect(screen.getByRole('button', { name: /records/i })).toHaveClass('Mui-selected');
+    });
+
+    it('activates records tab on /records/stats', () => {
+      renderWithRouter('/records/stats');
+      expect(screen.getByRole('button', { name: /records/i })).toHaveClass('Mui-selected');
+    });
+
+    it('activates records tab on legacy /daily-records path', () => {
+      renderWithRouter('/daily-records');
+      expect(screen.getByRole('button', { name: /records/i })).toHaveClass('Mui-selected');
+    });
+
+    it('activates records tab on legacy /statistics path', () => {
+      renderWithRouter('/statistics');
+      expect(screen.getByRole('button', { name: /records/i })).toHaveClass('Mui-selected');
     });
 
     it('activates purchases tab on /purchases', () => {
       renderWithRouter('/purchases');
-      const purchasesButton = screen.getByRole('button', { name: /purchases/i });
-      expect(purchasesButton).toHaveClass('Mui-selected');
+      expect(screen.getByRole('button', { name: /purchases/i })).toHaveClass('Mui-selected');
     });
 
     it('activates purchases tab on /purchases/new', () => {
       renderWithRouter('/purchases/new');
-      const purchasesButton = screen.getByRole('button', { name: /purchases/i });
-      expect(purchasesButton).toHaveClass('Mui-selected');
-    });
-
-    it('does not activate purchases tab on /dashboard', () => {
-      renderWithRouter('/dashboard');
-      const purchasesButton = screen.getByRole('button', { name: /purchases/i });
-      expect(purchasesButton).not.toHaveClass('Mui-selected');
+      expect(screen.getByRole('button', { name: /purchases/i })).toHaveClass('Mui-selected');
     });
 
     it('activates coops tab on /coops', () => {
       renderWithRouter('/coops');
-      const coopsButton = screen.getByRole('button', { name: /coops/i });
-      expect(coopsButton).toHaveClass('Mui-selected');
+      expect(screen.getByRole('button', { name: /coops/i })).toHaveClass('Mui-selected');
     });
 
     it('activates settings tab on /settings', () => {
       renderWithRouter('/settings');
-      const settingsButton = screen.getByRole('button', { name: /settings/i });
-      expect(settingsButton).toHaveClass('Mui-selected');
+      expect(screen.getByRole('button', { name: /settings/i })).toHaveClass('Mui-selected');
+    });
+
+    it('does not activate purchases tab on /dashboard', () => {
+      renderWithRouter('/dashboard');
+      expect(screen.getByRole('button', { name: /purchases/i })).not.toHaveClass('Mui-selected');
     });
   });
 
   describe('navigation on click', () => {
+    it('navigates to /records/list when clicking Records', async () => {
+      const user = userEvent.setup();
+      renderWithRouter('/dashboard');
+      await user.click(screen.getByRole('button', { name: /records/i }));
+      expect(mockNavigate).toHaveBeenCalledWith('/records/list');
+    });
+
     it('navigates to /purchases when clicking Purchases', async () => {
       const user = userEvent.setup();
       renderWithRouter('/dashboard');

--- a/frontend/src/locales/cs/translation.json
+++ b/frontend/src/locales/cs/translation.json
@@ -39,7 +39,8 @@
     "purchases": "Nákupy",
     "dailyRecords": "Denní záznamy",
     "statistics": "Statistiky",
-    "settings": "Nastavení"
+    "settings": "Nastavení",
+    "records": "Záznamy"
   },
   "dashboard": {
     "title": "Přehled",

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -39,7 +39,8 @@
     "purchases": "Purchases",
     "dailyRecords": "Daily Records",
     "statistics": "Statistics",
-    "settings": "Settings"
+    "settings": "Settings",
+    "records": "Records"
   },
   "dashboard": {
     "title": "Dashboard",

--- a/frontend/src/pages/RecordsPage.tsx
+++ b/frontend/src/pages/RecordsPage.tsx
@@ -1,0 +1,41 @@
+import { useEffect } from 'react'
+import { Routes, Route, Navigate, useLocation, useNavigate } from 'react-router-dom'
+import { Box, Tabs, Tab } from '@mui/material'
+import { useTranslation } from 'react-i18next'
+import { DailyRecordsListPage } from './DailyRecordsListPage'
+import StatisticsPage from './StatisticsPage'
+
+export function RecordsPage() {
+  const location = useLocation()
+  const navigate = useNavigate()
+  const { t } = useTranslation()
+
+  const currentTab = location.pathname.endsWith('/stats') ? 'stats' : 'list'
+
+  useEffect(() => {
+    // Redirect bare /records to /records/list
+    if (location.pathname === '/records' || location.pathname === '/records/') {
+      navigate('/records/list', { replace: true })
+    }
+  }, [location.pathname, navigate])
+
+  return (
+    <Box>
+      <Box sx={{ borderBottom: 1, borderColor: 'divider', bgcolor: 'background.paper', position: 'sticky', top: 64, zIndex: 900 }}>
+        <Tabs
+          value={currentTab}
+          onChange={(_, v: string) => navigate(`/records/${v}`)}
+          variant="fullWidth"
+        >
+          <Tab label={t('navigation.dailyRecords')} value="list" />
+          <Tab label={t('navigation.statistics')} value="stats" />
+        </Tabs>
+      </Box>
+      <Routes>
+        <Route path="list" element={<DailyRecordsListPage />} />
+        <Route path="stats" element={<StatisticsPage />} />
+        <Route index element={<Navigate to="list" replace />} />
+      </Routes>
+    </Box>
+  )
+}

--- a/frontend/src/pages/__tests__/RecordsPage.test.tsx
+++ b/frontend/src/pages/__tests__/RecordsPage.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { RecordsPage } from '../RecordsPage';
+
+// Mock child pages so tests stay fast and isolated
+vi.mock('../DailyRecordsListPage', () => ({
+  DailyRecordsListPage: () => <div data-testid="daily-records-page">Daily Records Content</div>,
+}));
+
+vi.mock('../StatisticsPage', () => ({
+  default: () => <div data-testid="statistics-page">Statistics Content</div>,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const map: Record<string, string> = {
+        'navigation.dailyRecords': 'Daily Records',
+        'navigation.statistics': 'Statistics',
+      };
+      return map[key] ?? key;
+    },
+  }),
+}));
+
+const renderAt = (path: string) =>
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/records/*" element={<RecordsPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+
+describe('RecordsPage', () => {
+  describe('Tab rendering', () => {
+    it('renders both tab labels', () => {
+      renderAt('/records/list');
+
+      expect(screen.getByRole('tab', { name: 'Daily Records' })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: 'Statistics' })).toBeInTheDocument();
+    });
+
+    it('renders the DailyRecordsListPage on /records/list', () => {
+      renderAt('/records/list');
+
+      expect(screen.getByTestId('daily-records-page')).toBeInTheDocument();
+      expect(screen.queryByTestId('statistics-page')).not.toBeInTheDocument();
+    });
+
+    it('renders StatisticsPage on /records/stats', () => {
+      renderAt('/records/stats');
+
+      expect(screen.getByTestId('statistics-page')).toBeInTheDocument();
+      expect(screen.queryByTestId('daily-records-page')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Active tab state', () => {
+    it('Daily Records tab is selected on /records/list', () => {
+      renderAt('/records/list');
+
+      const listTab = screen.getByRole('tab', { name: 'Daily Records' });
+      expect(listTab).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('Statistics tab is selected on /records/stats', () => {
+      renderAt('/records/stats');
+
+      const statsTab = screen.getByRole('tab', { name: 'Statistics' });
+      expect(statsTab).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('Statistics tab is not selected on /records/list', () => {
+      renderAt('/records/list');
+
+      const statsTab = screen.getByRole('tab', { name: 'Statistics' });
+      expect(statsTab).toHaveAttribute('aria-selected', 'false');
+    });
+  });
+
+  describe('Tab navigation', () => {
+    it('clicking Statistics tab shows StatisticsPage', async () => {
+      const user = userEvent.setup();
+      renderAt('/records/list');
+
+      await user.click(screen.getByRole('tab', { name: 'Statistics' }));
+
+      expect(screen.getByTestId('statistics-page')).toBeInTheDocument();
+    });
+
+    it('clicking Daily Records tab shows DailyRecordsListPage', async () => {
+      const user = userEvent.setup();
+      renderAt('/records/stats');
+
+      await user.click(screen.getByRole('tab', { name: 'Daily Records' }));
+
+      expect(screen.getByTestId('daily-records-page')).toBeInTheDocument();
+    });
+  });
+
+  describe('Default redirect', () => {
+    it('redirects /records/index to list tab', () => {
+      renderAt('/records');
+
+      // After redirect, daily records content should be visible
+      expect(screen.getByTestId('daily-records-page')).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Combines the separate Daily Records and Statistics pages into a single unified `RecordsPage` with an in-page tab switcher
- Reduces BottomNavigation from 6 items to 5 (Dashboard | Coops | Records | Purchases | Settings)
- Legacy routes `/daily-records` and `/statistics` redirect to new paths for backward compatibility

## Changes

- `frontend/src/pages/RecordsPage.tsx` — new wrapper page with MUI Tabs switching between `/records/list` and `/records/stats`
- `frontend/src/App.tsx` — added `/records/*` route, changed legacy routes to `<Navigate>` redirects
- `frontend/src/components/BottomNavigation.tsx` — merged two items into single "Records" item, now 5 items total
- `frontend/src/locales/en/translation.json` — added `navigation.records`
- `frontend/src/locales/cs/translation.json` — added `navigation.records` (Záznamy)

## Tests

- `frontend/src/pages/__tests__/RecordsPage.test.tsx` — 9 new tests: tab rendering, active tab state, tab navigation, default redirect
- `frontend/src/components/__tests__/BottomNavigation.test.tsx` — updated 16 tests: 5-item navigation, legacy path active tab detection, Records click navigates to `/records/list`

25 tests passing.

Closes #49