### PR TITLE
fix: Remove Quick Action Cards from Dashboard

### DIFF
--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,20 +1,13 @@
 import { useState } from 'react';
 import { Container, Box, Typography, Alert, Fab, Tooltip } from '@mui/material';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
 import AddIcon from '@mui/icons-material/Add';
-import EggIcon from '@mui/icons-material/Egg';
-import HomeIcon from '@mui/icons-material/Home';
-import PetsIcon from '@mui/icons-material/Pets';
-import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';
-import BarChartIcon from '@mui/icons-material/BarChart';
 import { useDashboardStats } from '@/features/dashboard/hooks/useDashboardStats';
 import { DashboardEmptyState } from '@/features/dashboard/components/DashboardEmptyState';
 import { TodaySummaryWidget } from '@/features/dashboard/components/TodaySummaryWidget';
 import { WeeklyProductionWidget } from '@/features/dashboard/components/WeeklyProductionWidget';
 import { FlockStatusWidget } from '@/features/dashboard/components/FlockStatusWidget';
 import { EggCostWidget } from '@/features/dashboard/components/EggCostWidget';
-import { QuickActionCard } from '@/features/dashboard/components/QuickActionCard';
 import { QuickAddModal } from '@/features/dailyRecords/components/QuickAddModal';
 import { useAllFlocks } from '@/features/flocks/hooks/useAllFlocks';
 
@@ -22,16 +15,15 @@ import { useAllFlocks } from '@/features/flocks/hooks/useAllFlocks';
  * Dashboard Page Component
  *
  * Main landing page after authentication.
- * Displays farm statistics and quick action cards for common tasks.
+ * Displays farm statistics.
  *
  * Layout:
  * - Statistics widgets at top (responsive grid)
- * - Quick action cards below
+ * - FAB for quick add daily record
  * - Empty state when no data available
  */
 export default function DashboardPage() {
   const { t } = useTranslation();
-  const navigate = useNavigate();
   const { data: stats, isLoading, error } = useDashboardStats();
   const { data: flocks = [] } = useAllFlocks();
   const [isQuickAddOpen, setIsQuickAddOpen] = useState(false);
@@ -39,7 +31,6 @@ export default function DashboardPage() {
   // Check if user has any data
   const hasData = stats && stats.activeFlocks > 0;
 
-  // Handler functions
   const handleAddDailyRecord = () => {
     setIsQuickAddOpen(true);
   };
@@ -47,45 +38,6 @@ export default function DashboardPage() {
   const handleCloseQuickAdd = () => {
     setIsQuickAddOpen(false);
   };
-
-  // Quick actions configuration
-  const quickActions = [
-    {
-      title: t('dashboard.quickActions.addDailyRecord'),
-      description: t('dashboard.quickActions.addDailyRecordDesc'),
-      icon: <EggIcon />,
-      onClick: handleAddDailyRecord,
-      disabled: flocks.length === 0,
-    },
-    {
-      title: t('dashboard.quickActions.manageCoops'),
-      description: t('dashboard.quickActions.manageCoopsDesc'),
-      icon: <HomeIcon />,
-      onClick: () => navigate('/coops'),
-      disabled: false,
-    },
-    {
-      title: t('dashboard.quickActions.manageFlocks'),
-      description: t('dashboard.quickActions.manageFlocksDesc'),
-      icon: <PetsIcon />,
-      onClick: () => navigate('/coops'),
-      disabled: false,
-    },
-    {
-      title: t('dashboard.quickActions.trackPurchases'),
-      description: t('dashboard.quickActions.trackPurchasesDesc'),
-      icon: <ShoppingCartIcon />,
-      onClick: () => navigate('/purchases'),
-      disabled: false,
-    },
-    {
-      title: t('dashboard.quickActions.viewStatistics'),
-      description: t('dashboard.quickActions.viewStatisticsDesc'),
-      icon: <BarChartIcon />,
-      onClick: () => navigate('/statistics'),
-      disabled: false,
-    },
-  ];
 
   return (
     <Container maxWidth="lg" sx={{ py: 3 }}>
@@ -105,85 +57,45 @@ export default function DashboardPage() {
         {/* Show empty state if no data and not loading */}
         {!isLoading && !hasData && <DashboardEmptyState />}
 
-        {/* Show dashboard content if has data or is loading */}
+        {/* Show stat widgets when has data or is loading */}
         {(isLoading || hasData) && (
-          <>
-            {/* Statistics Widgets Section */}
-            <Box sx={{ mb: 4 }}>
-              <Box
-                sx={{
-                  display: 'grid',
-                  gridTemplateColumns: {
-                    xs: '1fr',
-                    sm: 'repeat(2, 1fr)',
-                    md: 'repeat(4, 1fr)',
-                  },
-                  gap: 2,
-                }}
-              >
-                {/* Today's Summary */}
-                <TodaySummaryWidget
-                  eggsToday={stats?.todayEggs}
-                  loading={isLoading}
-                />
+          <Box
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: {
+                xs: '1fr',
+                sm: 'repeat(2, 1fr)',
+                md: 'repeat(4, 1fr)',
+              },
+              gap: 2,
+            }}
+          >
+            <TodaySummaryWidget
+              eggsToday={stats?.todayEggs}
+              loading={isLoading}
+            />
 
-                {/* Weekly Production */}
-                <WeeklyProductionWidget
-                  eggsThisWeek={stats?.thisWeekEggs}
-                  loading={isLoading}
-                />
+            <WeeklyProductionWidget
+              eggsThisWeek={stats?.thisWeekEggs}
+              loading={isLoading}
+            />
 
-                {/* Egg Cost Calculation */}
-                <EggCostWidget
-                  costPerEgg={stats?.costPerEgg ?? undefined}
-                  loading={isLoading}
-                />
+            <EggCostWidget
+              costPerEgg={stats?.costPerEgg ?? undefined}
+              loading={isLoading}
+            />
 
-                {/* Flock Status */}
-                <FlockStatusWidget
-                  totalHens={stats?.totalHens ?? 0}
-                  totalRoosters={stats?.totalRoosters ?? 0}
-                  totalChicks={stats?.totalChicks ?? 0}
-                  activeFlocks={stats?.activeFlocks ?? 0}
-                  loading={isLoading}
-                />
-              </Box>
-            </Box>
-
-            {/* Quick Actions Section */}
-            <Box>
-              <Typography variant="h6" gutterBottom fontWeight={600} sx={{ mb: 2 }}>
-                {t('dashboard.quickActions.title')}
-              </Typography>
-
-              <Box
-                sx={{
-                  display: 'grid',
-                  gridTemplateColumns: {
-                    xs: '1fr',
-                    sm: 'repeat(2, 1fr)',
-                    lg: 'repeat(4, 1fr)',
-                  },
-                  gap: 2,
-                }}
-              >
-                {quickActions.map((action) => (
-                  <QuickActionCard
-                    key={action.title}
-                    title={action.title}
-                    description={action.description}
-                    icon={action.icon}
-                    onClick={action.onClick}
-                    disabled={action.disabled}
-                  />
-                ))}
-              </Box>
-            </Box>
-          </>
+            <FlockStatusWidget
+              totalHens={stats?.totalHens ?? 0}
+              totalRoosters={stats?.totalRoosters ?? 0}
+              totalChicks={stats?.totalChicks ?? 0}
+              activeFlocks={stats?.activeFlocks ?? 0}
+              loading={isLoading}
+            />
+          </Box>
         )}
 
         {/* Floating Action Button - Add Daily Record */}
-        {/* Only show if user has data (flocks exist) */}
         {hasData && (
           <Tooltip title={t('dashboard.quickActions.addDailyRecord')} placement="left">
             <span>

--- a/frontend/src/pages/__tests__/DashboardPage.test.tsx
+++ b/frontend/src/pages/__tests__/DashboardPage.test.tsx
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import DashboardPage from '../DashboardPage';
+
+// Mock hooks
+const mockUseDashboardStats = vi.fn();
+const mockUseAllFlocks = vi.fn();
+
+vi.mock('@/features/dashboard/hooks/useDashboardStats', () => ({
+  useDashboardStats: () => mockUseDashboardStats(),
+}));
+
+vi.mock('@/features/flocks/hooks/useAllFlocks', () => ({
+  useAllFlocks: () => mockUseAllFlocks(),
+}));
+
+// Mock widgets and components
+vi.mock('@/features/dashboard/components/TodaySummaryWidget', () => ({
+  TodaySummaryWidget: () => <div data-testid="today-summary-widget" />,
+}));
+vi.mock('@/features/dashboard/components/WeeklyProductionWidget', () => ({
+  WeeklyProductionWidget: () => <div data-testid="weekly-production-widget" />,
+}));
+vi.mock('@/features/dashboard/components/FlockStatusWidget', () => ({
+  FlockStatusWidget: () => <div data-testid="flock-status-widget" />,
+}));
+vi.mock('@/features/dashboard/components/EggCostWidget', () => ({
+  EggCostWidget: () => <div data-testid="egg-cost-widget" />,
+}));
+vi.mock('@/features/dashboard/components/DashboardEmptyState', () => ({
+  DashboardEmptyState: () => <div data-testid="dashboard-empty-state" />,
+}));
+vi.mock('@/features/dailyRecords/components/QuickAddModal', () => ({
+  QuickAddModal: () => <div data-testid="quick-add-modal" />,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+function renderPage() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('DashboardPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('when user has data (active flocks)', () => {
+    beforeEach(() => {
+      mockUseDashboardStats.mockReturnValue({
+        data: { activeFlocks: 2, todayEggs: 10, thisWeekEggs: 50, costPerEgg: 0.5, totalHens: 20, totalRoosters: 2, totalChicks: 0 },
+        isLoading: false,
+        error: null,
+      });
+      mockUseAllFlocks.mockReturnValue({ data: [{ id: '1', name: 'Flock 1' }] });
+    });
+
+    it('renders stat widgets', () => {
+      renderPage();
+      expect(screen.getByTestId('today-summary-widget')).toBeInTheDocument();
+      expect(screen.getByTestId('weekly-production-widget')).toBeInTheDocument();
+      expect(screen.getByTestId('egg-cost-widget')).toBeInTheDocument();
+      expect(screen.getByTestId('flock-status-widget')).toBeInTheDocument();
+    });
+
+    it('does not render Quick Action Cards', () => {
+      renderPage();
+      expect(screen.queryByText('dashboard.quickActions.title')).not.toBeInTheDocument();
+      expect(screen.queryByText('dashboard.quickActions.manageCoops')).not.toBeInTheDocument();
+      expect(screen.queryByText('dashboard.quickActions.viewStatistics')).not.toBeInTheDocument();
+    });
+
+    it('renders the FAB', () => {
+      renderPage();
+      expect(screen.getByRole('button', { name: 'dashboard.quickActions.addDailyRecordAriaLabel' })).toBeInTheDocument();
+    });
+
+    it('does not render empty state', () => {
+      renderPage();
+      expect(screen.queryByTestId('dashboard-empty-state')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('when user has no data', () => {
+    beforeEach(() => {
+      mockUseDashboardStats.mockReturnValue({
+        data: { activeFlocks: 0, todayEggs: 0, thisWeekEggs: 0, costPerEgg: null, totalHens: 0, totalRoosters: 0, totalChicks: 0 },
+        isLoading: false,
+        error: null,
+      });
+      mockUseAllFlocks.mockReturnValue({ data: [] });
+    });
+
+    it('renders empty state', () => {
+      renderPage();
+      expect(screen.getByTestId('dashboard-empty-state')).toBeInTheDocument();
+    });
+
+    it('does not render stat widgets', () => {
+      renderPage();
+      expect(screen.queryByTestId('today-summary-widget')).not.toBeInTheDocument();
+    });
+
+    it('does not render FAB', () => {
+      renderPage();
+      expect(screen.queryByRole('button', { name: 'dashboard.quickActions.addDailyRecordAriaLabel' })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('loading state', () => {
+    beforeEach(() => {
+      mockUseDashboardStats.mockReturnValue({ data: undefined, isLoading: true, error: null });
+      mockUseAllFlocks.mockReturnValue({ data: [] });
+    });
+
+    it('renders widgets while loading', () => {
+      renderPage();
+      expect(screen.getByTestId('today-summary-widget')).toBeInTheDocument();
+    });
+
+    it('does not render empty state while loading', () => {
+      renderPage();
+      expect(screen.queryByTestId('dashboard-empty-state')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('error state', () => {
+    beforeEach(() => {
+      mockUseDashboardStats.mockReturnValue({ data: undefined, isLoading: false, error: new Error('Network error') });
+      mockUseAllFlocks.mockReturnValue({ data: [] });
+    });
+
+    it('renders error alert', () => {
+      renderPage();
+      expect(screen.getByText('Network error')).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Removes the Quick Action Cards section from `DashboardPage.tsx`. These cards duplicated navigation already available via the bottom bar (Coops, Purchases, Records). On mobile this caused unnecessary scroll and cognitive overhead.

## Changes

- `DashboardPage.tsx` — removed Quick Actions grid and `quickActions` array; removed unused icon imports (`EggIcon`, `HomeIcon`, `PetsIcon`, `ShoppingCartIcon`, `BarChartIcon`), `QuickActionCard` import, and `useNavigate`
- Dashboard now shows only: page title, error alert, stat widgets (loading/data state), FAB, QuickAddModal
- Empty state (`DashboardEmptyState`) already handles the no-data case

## Tests

- `DashboardPage.test.tsx` (new) — 10 tests covering: stat widgets rendered with data, no Quick Action Cards rendered, FAB present, empty state shown when no data, loading state shows widgets, error state shows alert

Closes #51