### PR TITLE
fix(#52): Collapsible filter section on Statistics page

### DIFF
--- a/frontend/src/locales/cs/translation.json
+++ b/frontend/src/locales/cs/translation.json
@@ -475,7 +475,8 @@
       "coop": "Kurník",
       "flock": "Hejno",
       "allCoops": "Všechny kurníky",
-      "allFlocks": "Všechna hejna"
+      "allFlocks": "Všechna hejna",
+      "summary": "{{range}} · {{flock}}"
     }
   },
   "errors": {

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -473,7 +473,8 @@
       "coop": "Coop",
       "flock": "Flock",
       "allCoops": "All Coops",
-      "allFlocks": "All Flocks"
+      "allFlocks": "All Flocks",
+      "summary": "{{range}} · {{flock}}"
     }
   },
   "errors": {

--- a/frontend/src/pages/StatisticsPage.tsx
+++ b/frontend/src/pages/StatisticsPage.tsx
@@ -4,8 +4,9 @@ import {
   Box,
   Typography,
   Paper,
-  Card,
-  CardContent,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
   ToggleButtonGroup,
   ToggleButton,
   Alert,
@@ -16,6 +17,7 @@ import {
   MenuItem,
 } from '@mui/material';
 import { useTranslation } from 'react-i18next';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
 import FilterListIcon from '@mui/icons-material/FilterList';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
@@ -95,6 +97,25 @@ export default function StatisticsPage() {
     setSelectedFlockId('');
   };
 
+  const activeDateLabel = (() => {
+    if (dateRange === '7') return t('statistics.dateRange.last7Days');
+    if (dateRange === '30') return t('statistics.dateRange.last30Days');
+    if (dateRange === '90') return t('statistics.dateRange.last90Days');
+    return t('statistics.dateRange.custom');
+  })();
+
+  const activeFlockLabel = (() => {
+    if (selectedFlockId) {
+      const flock = flocks?.find((f) => f.id === selectedFlockId);
+      return flock?.identifier ?? t('statistics.filters.allFlocks');
+    }
+    if (selectedCoopId) {
+      const coop = coops?.find((c) => c.id === selectedCoopId);
+      return coop?.name ?? t('statistics.filters.allCoops');
+    }
+    return t('statistics.filters.allFlocks');
+  })();
+
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale={i18n.language}>
       <Container maxWidth="lg" sx={{ py: 3 }}>
@@ -104,133 +125,140 @@ export default function StatisticsPage() {
             {t('statistics.title')}
           </Typography>
 
-          {/* Date Range Filters */}
-          <Card elevation={1} sx={{ mb: 3 }}>
-            <CardContent sx={{ p: 2, '&:last-child': { pb: 2 } }}>
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          {/* Collapsible Filters */}
+          <Accordion
+            defaultExpanded={false}
+            disableGutters
+            elevation={1}
+            sx={{ mb: 3, '&:before': { display: 'none' }, borderRadius: 1 }}
+          >
+            <AccordionSummary
+              expandIcon={<ExpandMoreIcon />}
+              aria-controls="statistics-filters-content"
+              id="statistics-filters-header"
+            >
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                <CalendarTodayIcon color="action" />
-                <Typography variant="subtitle1" fontWeight={600}>
-                  {t('statistics.dateRange.title')}
+                <FilterListIcon fontSize="small" color="action" />
+                <Typography variant="body2">
+                  {t('statistics.filters.summary', {
+                    range: activeDateLabel,
+                    flock: activeFlockLabel,
+                  })}
                 </Typography>
               </Box>
-
-              <ToggleButtonGroup
-                value={dateRange}
-                exclusive
-                onChange={handleDateRangeChange}
-                aria-label={t('statistics.dateRange.ariaLabel')}
-                fullWidth
-                sx={{
-                  '& .MuiToggleButton-root': {
-                    py: 1,
-                  },
-                }}
-              >
-                <ToggleButton value="7" aria-label={t('statistics.dateRange.last7Days')}>
-                  {t('statistics.dateRange.last7Days')}
-                </ToggleButton>
-                <ToggleButton value="30" aria-label={t('statistics.dateRange.last30Days')}>
-                  {t('statistics.dateRange.last30Days')}
-                </ToggleButton>
-                <ToggleButton value="90" aria-label={t('statistics.dateRange.last90Days')}>
-                  {t('statistics.dateRange.last90Days')}
-                </ToggleButton>
-                <ToggleButton value="custom" aria-label={t('statistics.dateRange.custom')}>
-                  {t('statistics.dateRange.custom')}
-                </ToggleButton>
-              </ToggleButtonGroup>
-
-              {/* Custom Date Range Pickers */}
-              {dateRange === 'custom' && (
-                <Box
-                  sx={{
-                    display: 'flex',
-                    flexDirection: { xs: 'column', sm: 'row' },
-                    gap: 2,
-                  }}
-                >
-                  <DatePicker
-                    label={t('statistics.dateRange.startDate')}
-                    value={customStartDate}
-                    onChange={(newValue) => setCustomStartDate(newValue)}
-                    maxDate={customEndDate || dayjs()}
-                    slotProps={{
-                      textField: {
-                        fullWidth: true,
-                      },
-                    }}
-                  />
-                  <DatePicker
-                    label={t('statistics.dateRange.endDate')}
-                    value={customEndDate}
-                    onChange={(newValue) => setCustomEndDate(newValue)}
-                    minDate={customStartDate || undefined}
-                    maxDate={dayjs()}
-                    slotProps={{
-                      textField: {
-                        fullWidth: true,
-                      },
-                    }}
-                  />
-                </Box>
-              )}
-            </Box>
-            </CardContent>
-          </Card>
-
-          {/* Coop / Flock Filters */}
-          <Card elevation={1} sx={{ mb: 3 }}>
-            <CardContent sx={{ p: 2, '&:last-child': { pb: 2 } }}>
+            </AccordionSummary>
+            <AccordionDetails sx={{ pt: 0 }}>
               <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                  <FilterListIcon color="action" />
-                  <Typography variant="subtitle1" fontWeight={600}>
-                    {t('statistics.filters.title')}
-                  </Typography>
-                </Box>
-                <Box
-                  sx={{
-                    display: 'flex',
-                    flexDirection: { xs: 'column', sm: 'row' },
-                    gap: 2,
-                  }}
-                >
-                  <FormControl fullWidth>
-                    <InputLabel>{t('statistics.filters.coop')}</InputLabel>
-                    <Select
-                      value={selectedCoopId}
-                      label={t('statistics.filters.coop')}
-                      onChange={(e) => handleCoopChange(e.target.value)}
-                    >
-                      <MenuItem value="">{t('statistics.filters.allCoops')}</MenuItem>
-                      {coops?.filter((c) => c.isActive).map((coop) => (
-                        <MenuItem key={coop.id} value={coop.id}>
-                          {coop.name}
-                        </MenuItem>
-                      ))}
-                    </Select>
-                  </FormControl>
+                {/* Date Range */}
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <CalendarTodayIcon color="action" fontSize="small" />
+                    <Typography variant="subtitle2" fontWeight={600}>
+                      {t('statistics.dateRange.title')}
+                    </Typography>
+                  </Box>
 
-                  <FormControl fullWidth disabled={!selectedCoopId}>
-                    <InputLabel>{t('statistics.filters.flock')}</InputLabel>
-                    <Select
-                      value={selectedFlockId}
-                      label={t('statistics.filters.flock')}
-                      onChange={(e) => setSelectedFlockId(e.target.value)}
+                  <ToggleButtonGroup
+                    value={dateRange}
+                    exclusive
+                    onChange={handleDateRangeChange}
+                    aria-label={t('statistics.dateRange.ariaLabel')}
+                    fullWidth
+                    sx={{ '& .MuiToggleButton-root': { py: 1 } }}
+                  >
+                    <ToggleButton value="7" aria-label={t('statistics.dateRange.last7Days')}>
+                      {t('statistics.dateRange.last7Days')}
+                    </ToggleButton>
+                    <ToggleButton value="30" aria-label={t('statistics.dateRange.last30Days')}>
+                      {t('statistics.dateRange.last30Days')}
+                    </ToggleButton>
+                    <ToggleButton value="90" aria-label={t('statistics.dateRange.last90Days')}>
+                      {t('statistics.dateRange.last90Days')}
+                    </ToggleButton>
+                    <ToggleButton value="custom" aria-label={t('statistics.dateRange.custom')}>
+                      {t('statistics.dateRange.custom')}
+                    </ToggleButton>
+                  </ToggleButtonGroup>
+
+                  {/* Custom Date Range Pickers */}
+                  {dateRange === 'custom' && (
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        flexDirection: { xs: 'column', sm: 'row' },
+                        gap: 2,
+                      }}
                     >
-                      <MenuItem value="">{t('statistics.filters.allFlocks')}</MenuItem>
-                      {flocks?.map((flock) => (
-                        <MenuItem key={flock.id} value={flock.id}>
-                          {flock.identifier}
-                        </MenuItem>
-                      ))}
-                    </Select>
-                  </FormControl>
+                      <DatePicker
+                        label={t('statistics.dateRange.startDate')}
+                        value={customStartDate}
+                        onChange={(newValue) => setCustomStartDate(newValue)}
+                        maxDate={customEndDate || dayjs()}
+                        slotProps={{ textField: { fullWidth: true } }}
+                      />
+                      <DatePicker
+                        label={t('statistics.dateRange.endDate')}
+                        value={customEndDate}
+                        onChange={(newValue) => setCustomEndDate(newValue)}
+                        minDate={customStartDate || undefined}
+                        maxDate={dayjs()}
+                        slotProps={{ textField: { fullWidth: true } }}
+                      />
+                    </Box>
+                  )}
+                </Box>
+
+                {/* Coop / Flock Filters */}
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <FilterListIcon color="action" fontSize="small" />
+                    <Typography variant="subtitle2" fontWeight={600}>
+                      {t('statistics.filters.title')}
+                    </Typography>
+                  </Box>
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      flexDirection: { xs: 'column', sm: 'row' },
+                      gap: 2,
+                    }}
+                  >
+                    <FormControl fullWidth>
+                      <InputLabel>{t('statistics.filters.coop')}</InputLabel>
+                      <Select
+                        value={selectedCoopId}
+                        label={t('statistics.filters.coop')}
+                        onChange={(e) => handleCoopChange(e.target.value)}
+                      >
+                        <MenuItem value="">{t('statistics.filters.allCoops')}</MenuItem>
+                        {coops?.filter((c) => c.isActive).map((coop) => (
+                          <MenuItem key={coop.id} value={coop.id}>
+                            {coop.name}
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    </FormControl>
+
+                    <FormControl fullWidth disabled={!selectedCoopId}>
+                      <InputLabel>{t('statistics.filters.flock')}</InputLabel>
+                      <Select
+                        value={selectedFlockId}
+                        label={t('statistics.filters.flock')}
+                        onChange={(e) => setSelectedFlockId(e.target.value)}
+                      >
+                        <MenuItem value="">{t('statistics.filters.allFlocks')}</MenuItem>
+                        {flocks?.map((flock) => (
+                          <MenuItem key={flock.id} value={flock.id}>
+                            {flock.identifier}
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    </FormControl>
+                  </Box>
                 </Box>
               </Box>
-            </CardContent>
-          </Card>
+            </AccordionDetails>
+          </Accordion>
 
           {/* Summary StatCards */}
           <Box

--- a/frontend/src/pages/__tests__/StatisticsPage.test.tsx
+++ b/frontend/src/pages/__tests__/StatisticsPage.test.tsx
@@ -1,0 +1,246 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BrowserRouter } from 'react-router-dom';
+import StatisticsPage from '../StatisticsPage';
+
+// Mock hooks
+const mockUseStatistics = vi.fn();
+const mockUseCoops = vi.fn();
+const mockUseFlocks = vi.fn();
+
+vi.mock('@/features/statistics/hooks/useStatistics', () => ({
+  useStatistics: (...args: unknown[]) => mockUseStatistics(...args),
+}));
+
+vi.mock('@/features/coops/hooks/useCoops', () => ({
+  useCoops: () => mockUseCoops(),
+}));
+
+vi.mock('@/features/flocks/hooks/useFlocks', () => ({
+  useFlocks: (...args: unknown[]) => mockUseFlocks(...args),
+}));
+
+// Mock chart components to avoid canvas issues
+vi.mock('@/features/statistics/components/EggCostBreakdownChart', () => ({
+  EggCostBreakdownChart: () => <div data-testid="egg-cost-chart" />,
+}));
+vi.mock('@/features/statistics/components/ProductionTrendChart', () => ({
+  ProductionTrendChart: () => <div data-testid="production-chart" />,
+}));
+vi.mock('@/features/statistics/components/CostPerEggTrendChart', () => ({
+  CostPerEggTrendChart: () => <div data-testid="cost-per-egg-chart" />,
+}));
+vi.mock('@/features/statistics/components/FlockProductivityChart', () => ({
+  FlockProductivityChart: () => <div data-testid="flock-productivity-chart" />,
+}));
+
+// Mock StatCard
+vi.mock('@/shared/components', () => ({
+  StatCard: ({ label }: { label: string }) => <div data-testid="stat-card">{label}</div>,
+}));
+
+// Mock MUI DatePicker to avoid full calendar rendering
+vi.mock('@mui/x-date-pickers/DatePicker', () => ({
+  DatePicker: ({ label }: { label: string }) => (
+    <input aria-label={label} data-testid="date-picker" />
+  ),
+}));
+vi.mock('@mui/x-date-pickers/LocalizationProvider', () => ({
+  LocalizationProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('@mui/x-date-pickers/AdapterDayjs', () => ({
+  AdapterDayjs: class {},
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, unknown>) => {
+      const translations: Record<string, string> = {
+        'statistics.title': 'Statistics',
+        'statistics.dateRange.title': 'Time Period',
+        'statistics.dateRange.ariaLabel': 'Select time period',
+        'statistics.dateRange.last7Days': '7 days',
+        'statistics.dateRange.last30Days': '30 days',
+        'statistics.dateRange.last90Days': '90 days',
+        'statistics.dateRange.custom': 'Custom',
+        'statistics.dateRange.startDate': 'Start Date',
+        'statistics.dateRange.endDate': 'End Date',
+        'statistics.filters.title': 'Filters',
+        'statistics.filters.coop': 'Coop',
+        'statistics.filters.flock': 'Flock',
+        'statistics.filters.allCoops': 'All Coops',
+        'statistics.filters.allFlocks': 'All Flocks',
+        'statistics.filters.summary': `${params?.range ?? ''} · ${params?.flock ?? ''}`,
+        'statistics.summary.totalEggs': 'Total Eggs',
+        'statistics.summary.totalCost': 'Total Costs',
+        'statistics.summary.avgCostPerEgg': 'Avg. Cost/Egg',
+        'statistics.error.loadFailed': 'Failed to load statistics',
+        'statistics.emptyState.noData': 'No data for selected period',
+      };
+      return translations[key] ?? key;
+    },
+    i18n: { language: 'en' },
+  }),
+}));
+
+const mockStats = {
+  summary: { totalEggs: 100, totalCost: 50, avgCostPerEgg: 0.5 },
+  costBreakdown: [],
+  productionTrend: [{ date: '2024-01-01', eggs: 10 }],
+  costPerEggTrend: [],
+  flockProductivity: [],
+};
+
+describe('StatisticsPage', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    vi.clearAllMocks();
+
+    mockUseStatistics.mockReturnValue({ data: mockStats, isLoading: false, error: null });
+    mockUseCoops.mockReturnValue({ data: [] });
+    mockUseFlocks.mockReturnValue({ data: [] });
+  });
+
+  const renderPage = () =>
+    render(
+      <BrowserRouter>
+        <QueryClientProvider client={queryClient}>
+          <StatisticsPage />
+        </QueryClientProvider>
+      </BrowserRouter>
+    );
+
+  describe('page structure', () => {
+    it('renders page title', () => {
+      renderPage();
+      expect(screen.getByRole('heading', { name: 'Statistics' })).toBeInTheDocument();
+    });
+
+    it('renders stat cards', () => {
+      renderPage();
+      expect(screen.getAllByTestId('stat-card')).toHaveLength(3);
+    });
+  });
+
+  describe('collapsible filter accordion', () => {
+    it('renders filter accordion collapsed by default', () => {
+      renderPage();
+      // AccordionDetails should not be visible (MUI hides content when collapsed)
+      // The panel is collapsed — aria-expanded should be false on the header button
+      const header = document.getElementById('statistics-filters-header');
+      expect(header?.getAttribute('aria-expanded')).toBe('false');
+    });
+
+    it('shows filter summary with default date range and flock label', () => {
+      renderPage();
+      expect(screen.getByText('30 days · All Flocks')).toBeInTheDocument();
+    });
+
+    it('expands accordion when clicking the summary', async () => {
+      const user = userEvent.setup();
+      renderPage();
+
+      const header = document.getElementById('statistics-filters-header');
+      await user.click(header!);
+
+      expect(header?.getAttribute('aria-expanded')).toBe('true');
+    });
+
+    it('shows date range toggle buttons when expanded', async () => {
+      const user = userEvent.setup();
+      renderPage();
+
+      await user.click(document.getElementById('statistics-filters-header')!);
+
+      expect(screen.getByRole('button', { name: '7 days' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: '30 days' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: '90 days' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Custom' })).toBeInTheDocument();
+    });
+
+    it('shows coop and flock selects when expanded', async () => {
+      const user = userEvent.setup();
+      renderPage();
+
+      await user.click(document.getElementById('statistics-filters-header')!);
+
+      expect(screen.getAllByText('Coop').length).toBeGreaterThan(0);
+      expect(screen.getAllByText('Flock').length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('filter summary label updates', () => {
+    it('updates summary when date range changes to 7 days', async () => {
+      const user = userEvent.setup();
+      renderPage();
+
+      // Expand accordion first
+      await user.click(document.getElementById('statistics-filters-header')!);
+
+      // Click 7 days button
+      await user.click(screen.getByRole('button', { name: '7 days' }));
+
+      expect(screen.getByText('7 days · All Flocks')).toBeInTheDocument();
+    });
+
+    it('updates summary when date range changes to 90 days', async () => {
+      const user = userEvent.setup();
+      renderPage();
+
+      await user.click(document.getElementById('statistics-filters-header')!);
+      await user.click(screen.getByRole('button', { name: '90 days' }));
+
+      expect(screen.getByText('90 days · All Flocks')).toBeInTheDocument();
+    });
+  });
+
+  describe('loading state', () => {
+    it('shows skeletons while loading', () => {
+      mockUseStatistics.mockReturnValue({ data: undefined, isLoading: true, error: null });
+      renderPage();
+
+      // MUI Skeleton renders as a div — check there are multiple
+      const skeletons = document.querySelectorAll('.MuiSkeleton-root');
+      expect(skeletons.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('error state', () => {
+    it('shows error alert when statistics fail to load', () => {
+      mockUseStatistics.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        error: new Error('Network error'),
+      });
+      renderPage();
+
+      expect(screen.getByText('Failed to load statistics')).toBeInTheDocument();
+    });
+  });
+
+  describe('charts', () => {
+    it('renders all four charts when data is available', () => {
+      renderPage();
+      expect(screen.getByTestId('egg-cost-chart')).toBeInTheDocument();
+      expect(screen.getByTestId('production-chart')).toBeInTheDocument();
+      expect(screen.getByTestId('cost-per-egg-chart')).toBeInTheDocument();
+      expect(screen.getByTestId('flock-productivity-chart')).toBeInTheDocument();
+    });
+
+    it('shows empty state when production trend is empty', () => {
+      mockUseStatistics.mockReturnValue({
+        data: { ...mockStats, productionTrend: [] },
+        isLoading: false,
+        error: null,
+      });
+      renderPage();
+      expect(screen.getByText('No data for selected period')).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
Closes #52

## Changes

- Replaced two separate filter Cards (date range + coop/flock) with a single collapsible MUI `Accordion`
- Accordion is **collapsed by default** — charts are visible immediately on mobile without scrolling
- Accordion summary line shows active filter state: e.g. `30 days · All Flocks`
- All existing filter controls (toggle buttons, custom date pickers, coop/flock selects) preserved inside `AccordionDetails`
- Added `statistics.filters.summary` translation key (EN + CS)

## Tests

13 new tests covering:
- Page structure (title, stat cards)
- Accordion collapsed by default
- Summary label reflects active filters
- Expanding reveals filter controls
- Date range selection updates summary
- Loading/error/empty states