### PR TITLE
fix(#53): dynamic AppBar title and back button on detail pages

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,15 +20,16 @@ import { useAuth } from '@clerk/clerk-react'
 import { startAutoSync } from './lib/syncManager'
 import { Box, AppBar, Toolbar, Typography, IconButton } from '@mui/material'
 import AccountCircleIcon from '@mui/icons-material/AccountCircle'
+import ArrowBackIcon from '@mui/icons-material/ArrowBack'
+import { AppBarProvider, useAppBar } from './context/AppBarContext'
 
-function App() {
-  // Initialize API client with Clerk authentication
+function AppInner() {
   useApiClient()
   const { isSignedIn } = useAuth()
   const navigate = useNavigate()
   const [bannerVisible, setBannerVisible] = useState(false)
+  const { title, onBack } = useAppBar()
 
-  // Start offline sync manager
   useEffect(() => {
     startAutoSync()
   }, [])
@@ -44,21 +45,34 @@ function App() {
           sx={{ top: 0, zIndex: 1100, height: 64 }}
         >
           <Toolbar sx={{ minHeight: '64px !important', px: 2 }}>
+            {onBack ? (
+              <IconButton
+                edge="start"
+                onClick={onBack}
+                aria-label="back"
+                size="medium"
+                sx={{ mr: 1, p: 1 }}
+              >
+                <ArrowBackIcon />
+              </IconButton>
+            ) : null}
             <Typography
               variant="h6"
               component="div"
               sx={{ flexGrow: 1, fontWeight: 700, color: 'primary.main', letterSpacing: 0.5 }}
             >
-              Chickquita
+              {title ?? 'Chickquita'}
             </Typography>
-            <IconButton
-              onClick={() => navigate('/settings')}
-              aria-label="settings"
-              size="medium"
-              sx={{ p: 1 }}
-            >
-              <AccountCircleIcon />
-            </IconButton>
+            {!onBack && (
+              <IconButton
+                onClick={() => navigate('/settings')}
+                aria-label="settings"
+                size="medium"
+                sx={{ p: 1 }}
+              >
+                <AccountCircleIcon />
+              </IconButton>
+            )}
           </Toolbar>
         </AppBar>
       )}
@@ -164,6 +178,14 @@ function App() {
       </Box>
       {isSignedIn && <BottomNavigation />}
     </>
+  )
+}
+
+function App() {
+  return (
+    <AppBarProvider>
+      <AppInner />
+    </AppBarProvider>
   )
 }
 

--- a/frontend/src/context/AppBarContext.tsx
+++ b/frontend/src/context/AppBarContext.tsx
@@ -1,0 +1,40 @@
+import { createContext, useContext, useState, useCallback } from 'react';
+import type { ReactNode } from 'react';
+
+interface AppBarState {
+  title: string | null;
+  onBack: (() => void) | null;
+}
+
+interface AppBarContextValue extends AppBarState {
+  setAppBar: (state: Partial<AppBarState>) => void;
+  resetAppBar: () => void;
+}
+
+const AppBarContext = createContext<AppBarContextValue>({
+  title: null,
+  onBack: null,
+  setAppBar: () => {},
+  resetAppBar: () => {},
+});
+
+export function AppBarProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<AppBarState>({ title: null, onBack: null });
+
+  const setAppBar = useCallback((newState: Partial<AppBarState>) => {
+    setState((prev) => ({ ...prev, ...newState }));
+  }, []);
+
+  const resetAppBar = useCallback(() => {
+    setState({ title: null, onBack: null });
+  }, []);
+
+  return (
+    <AppBarContext.Provider value={{ ...state, setAppBar, resetAppBar }}>
+      {children}
+    </AppBarContext.Provider>
+  );
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const useAppBar = () => useContext(AppBarContext);

--- a/frontend/src/context/__tests__/AppBarContext.test.tsx
+++ b/frontend/src/context/__tests__/AppBarContext.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AppBarProvider, useAppBar } from '../AppBarContext';
+
+function TestConsumer() {
+  const { title, onBack, setAppBar, resetAppBar } = useAppBar();
+  return (
+    <div>
+      <span data-testid="title">{title ?? 'null'}</span>
+      <span data-testid="has-back">{onBack ? 'yes' : 'no'}</span>
+      <button onClick={() => setAppBar({ title: 'New Title' })}>set title</button>
+      <button onClick={() => setAppBar({ onBack: () => {} })}>set back</button>
+      <button onClick={() => resetAppBar()}>reset</button>
+    </div>
+  );
+}
+
+describe('AppBarContext', () => {
+  it('provides null defaults', () => {
+    render(
+      <AppBarProvider>
+        <TestConsumer />
+      </AppBarProvider>
+    );
+    expect(screen.getByTestId('title')).toHaveTextContent('null');
+    expect(screen.getByTestId('has-back')).toHaveTextContent('no');
+  });
+
+  it('setAppBar updates title', async () => {
+    const user = userEvent.setup();
+    render(
+      <AppBarProvider>
+        <TestConsumer />
+      </AppBarProvider>
+    );
+    await user.click(screen.getByText('set title'));
+    expect(screen.getByTestId('title')).toHaveTextContent('New Title');
+  });
+
+  it('setAppBar updates onBack', async () => {
+    const user = userEvent.setup();
+    render(
+      <AppBarProvider>
+        <TestConsumer />
+      </AppBarProvider>
+    );
+    await user.click(screen.getByText('set back'));
+    expect(screen.getByTestId('has-back')).toHaveTextContent('yes');
+  });
+
+  it('setAppBar merges state (does not wipe other fields)', async () => {
+    const user = userEvent.setup();
+    render(
+      <AppBarProvider>
+        <TestConsumer />
+      </AppBarProvider>
+    );
+    await user.click(screen.getByText('set title'));
+    await user.click(screen.getByText('set back'));
+    expect(screen.getByTestId('title')).toHaveTextContent('New Title');
+    expect(screen.getByTestId('has-back')).toHaveTextContent('yes');
+  });
+
+  it('resetAppBar clears title and onBack', async () => {
+    const user = userEvent.setup();
+    render(
+      <AppBarProvider>
+        <TestConsumer />
+      </AppBarProvider>
+    );
+    await user.click(screen.getByText('set title'));
+    await user.click(screen.getByText('set back'));
+    await user.click(screen.getByText('reset'));
+    expect(screen.getByTestId('title')).toHaveTextContent('null');
+    expect(screen.getByTestId('has-back')).toHaveTextContent('no');
+  });
+
+  it('useAppBar outside provider returns default no-op values', () => {
+    // Default context value — should not throw
+    render(<TestConsumer />);
+    expect(screen.getByTestId('title')).toHaveTextContent('null');
+    expect(screen.getByTestId('has-back')).toHaveTextContent('no');
+  });
+});

--- a/frontend/src/features/flocks/components/FlockHistoryPage.tsx
+++ b/frontend/src/features/flocks/components/FlockHistoryPage.tsx
@@ -1,9 +1,10 @@
+import { useEffect, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { Box, Container, IconButton, Typography } from '@mui/material';
-import { ArrowBack as ArrowBackIcon } from '@mui/icons-material';
+import { Container } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { useFlockHistory } from '../hooks/useFlockHistory';
 import { FlockHistoryTimeline } from './FlockHistoryTimeline';
+import { useAppBar } from '../../../context/AppBarContext';
 
 /**
  * Full page view for flock history timeline.
@@ -13,31 +14,21 @@ export function FlockHistoryPage() {
   const { t } = useTranslation();
   const { coopId, flockId } = useParams<{ coopId: string; flockId: string }>();
   const navigate = useNavigate();
+  const { setAppBar, resetAppBar } = useAppBar();
 
   const { data: history, isLoading, error } = useFlockHistory(flockId || '');
 
-  const handleBack = () => {
+  const handleBack = useCallback(() => {
     navigate(`/coops/${coopId}/flocks/${flockId}`);
-  };
+  }, [navigate, coopId, flockId]);
+
+  useEffect(() => {
+    setAppBar({ title: t('flockHistory.title'), onBack: handleBack });
+    return () => resetAppBar();
+  }, [handleBack, t, setAppBar, resetAppBar]);
 
   return (
     <Container maxWidth="md" sx={{ py: 3 }}>
-      {/* Header */}
-      <Box display="flex" alignItems="center" mb={3}>
-        <IconButton
-          edge="start"
-          onClick={handleBack}
-          aria-label={t('common.back', 'Back')}
-          sx={{ mr: 2, minWidth: 48, minHeight: 48 }}
-        >
-          <ArrowBackIcon fontSize="large" />
-        </IconButton>
-        <Typography variant="h4" component="h1" fontWeight="bold">
-          {t('flockHistory.title', 'Flock History')}
-        </Typography>
-      </Box>
-
-      {/* Timeline */}
       <FlockHistoryTimeline history={history || []} loading={isLoading} error={error} />
     </Container>
   );

--- a/frontend/src/features/flocks/components/__tests__/FlockHistoryPage.test.tsx
+++ b/frontend/src/features/flocks/components/__tests__/FlockHistoryPage.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { FlockHistoryPage } from '../FlockHistoryPage';
+
+const mockSetAppBar = vi.fn();
+const mockResetAppBar = vi.fn();
+
+vi.mock('../../../../context/AppBarContext', async () => {
+  const actual = await vi.importActual('../../../../context/AppBarContext');
+  return {
+    ...actual,
+    useAppBar: () => ({
+      title: null,
+      onBack: null,
+      setAppBar: mockSetAppBar,
+      resetAppBar: mockResetAppBar,
+    }),
+  };
+});
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      if (key === 'flockHistory.title') return 'Flock History';
+      return key;
+    },
+  }),
+}));
+
+vi.mock('../../hooks/useFlockHistory', () => ({
+  useFlockHistory: vi.fn(() => ({
+    data: [],
+    isLoading: false,
+    error: null,
+  })),
+}));
+
+vi.mock('../FlockHistoryTimeline', () => ({
+  FlockHistoryTimeline: ({ loading }: { loading: boolean }) => (
+    <div data-testid="timeline">{loading ? 'Loading...' : 'Timeline'}</div>
+  ),
+}));
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={['/coops/coop-1/flocks/flock-1/history']}>
+      <Routes>
+        <Route path="/coops/:coopId/flocks/:flockId/history" element={<FlockHistoryPage />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('FlockHistoryPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls setAppBar with history title and onBack', () => {
+    renderPage();
+    expect(mockSetAppBar).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Flock History', onBack: expect.any(Function) })
+    );
+  });
+
+  it('calls resetAppBar on unmount', () => {
+    const { unmount } = renderPage();
+    unmount();
+    expect(mockResetAppBar).toHaveBeenCalled();
+  });
+
+  it('renders the timeline component', () => {
+    renderPage();
+    expect(screen.getByTestId('timeline')).toBeInTheDocument();
+  });
+
+  it('does not render an inline page header', () => {
+    renderPage();
+    expect(screen.queryByRole('heading')).not.toBeInTheDocument();
+    const backButtons = screen.queryAllByRole('button', { name: /back/i });
+    expect(backButtons).toHaveLength(0);
+  });
+});

--- a/frontend/src/pages/CoopDetailPage.tsx
+++ b/frontend/src/pages/CoopDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
@@ -9,15 +9,14 @@ import {
   Stack,
   Button,
   Chip,
-  IconButton,
   Tooltip,
 } from '@mui/material';
 import {
-  ArrowBack as ArrowBackIcon,
   Edit as EditIcon,
   Archive as ArchiveIcon,
   Delete as DeleteIcon,
 } from '@mui/icons-material';
+import { useAppBar } from '../context/AppBarContext';
 import { useCoopDetail } from '../features/coops/hooks/useCoopDetail';
 import { useArchiveCoop, useDeleteCoop } from '../features/coops/hooks/useCoops';
 import { EditCoopModal } from '../features/coops/components/EditCoopModal';
@@ -42,10 +41,16 @@ export function CoopDetailPage() {
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [isArchiveDialogOpen, setIsArchiveDialogOpen] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const { setAppBar, resetAppBar } = useAppBar();
 
-  const handleBack = () => {
+  const handleBack = useCallback(() => {
     navigate('/coops');
-  };
+  }, [navigate]);
+
+  useEffect(() => {
+    setAppBar({ title: coop?.name ?? t('coops.details'), onBack: handleBack });
+    return () => resetAppBar();
+  }, [coop?.name, handleBack, t, setAppBar, resetAppBar]);
 
   const handleEdit = () => {
     setIsEditModalOpen(true);
@@ -132,11 +137,6 @@ export function CoopDetailPage() {
     // For other errors, show a generic error with back button
     return (
       <Container maxWidth="sm" sx={{ py: 3 }}>
-        <Box sx={{ mb: 3 }}>
-          <IconButton onClick={handleBack} edge="start">
-            <ArrowBackIcon />
-          </IconButton>
-        </Box>
         <Typography variant="h6" color="error" gutterBottom>
           {t(processedError.translationKey)}
         </Typography>
@@ -153,25 +153,6 @@ export function CoopDetailPage() {
 
   return (
     <Container maxWidth="sm" sx={{ py: 3 }}>
-      {/* Header with Back Button */}
-      <Box sx={{ mb: 3 }}>
-        <IconButton
-          onClick={handleBack}
-          edge="start"
-          aria-label={t('common.back')}
-          sx={{
-            mb: 2,
-            minWidth: 48,
-            minHeight: 48,
-          }}
-        >
-          <ArrowBackIcon fontSize="large" />
-        </IconButton>
-        <Typography variant="h4" component="h1" gutterBottom>
-          {t('coops.details')}
-        </Typography>
-      </Box>
-
       {/* Coop Details Card */}
       <Paper elevation={2} sx={{ p: 3 }}>
         <Stack spacing={3}>

--- a/frontend/src/pages/FlockDetailPage.tsx
+++ b/frontend/src/pages/FlockDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
@@ -10,12 +10,10 @@ import {
   Button,
   Chip,
   Grid,
-  IconButton,
   Divider,
   Tooltip,
 } from '@mui/material';
 import {
-  ArrowBack as ArrowBackIcon,
   Edit as EditIcon,
   Archive as ArchiveIcon,
   History as HistoryIcon,
@@ -25,6 +23,7 @@ import {
   EggAlt as EggAltIcon,
   Diversity3 as Diversity3Icon,
 } from '@mui/icons-material';
+import { useAppBar } from '../context/AppBarContext';
 import { useFlockDetail } from '../features/flocks/hooks/useFlocks';
 import { useArchiveFlock } from '../features/flocks/hooks/useFlocks';
 import { EditFlockModal } from '../features/flocks/components/EditFlockModal';
@@ -49,10 +48,16 @@ export function FlockDetailPage() {
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [isArchiveDialogOpen, setIsArchiveDialogOpen] = useState(false);
   const [isMatureChicksModalOpen, setIsMatureChicksModalOpen] = useState(false);
+  const { setAppBar, resetAppBar } = useAppBar();
 
-  const handleBack = () => {
+  const handleBack = useCallback(() => {
     navigate(`/coops/${coopId}/flocks`);
-  };
+  }, [navigate, coopId]);
+
+  useEffect(() => {
+    setAppBar({ title: flock?.identifier ?? t('flocks.details'), onBack: handleBack });
+    return () => resetAppBar();
+  }, [flock?.identifier, handleBack, t, setAppBar, resetAppBar]);
 
   const handleEdit = () => {
     setIsEditModalOpen(true);
@@ -113,11 +118,6 @@ export function FlockDetailPage() {
 
     return (
       <Container maxWidth="sm" sx={{ py: 3 }}>
-        <Box sx={{ mb: 3 }}>
-          <IconButton onClick={handleBack} edge="start">
-            <ArrowBackIcon />
-          </IconButton>
-        </Box>
         <Typography variant="h6" color="error" gutterBottom>
           {t(processedError.translationKey)}
         </Typography>
@@ -136,25 +136,6 @@ export function FlockDetailPage() {
 
   return (
     <Container maxWidth="sm" sx={{ py: 3 }}>
-      {/* Header with Back Button */}
-      <Box sx={{ mb: 3 }}>
-        <IconButton
-          onClick={handleBack}
-          edge="start"
-          aria-label={t('common.back')}
-          sx={{
-            mb: 2,
-            minWidth: 48,
-            minHeight: 48,
-          }}
-        >
-          <ArrowBackIcon fontSize="large" />
-        </IconButton>
-        <Typography variant="h4" component="h1" gutterBottom>
-          {t('flocks.details')}
-        </Typography>
-      </Box>
-
       {/* Flock Details Card */}
       <Paper elevation={2} sx={{ p: 3 }}>
         <Stack spacing={3}>

--- a/frontend/src/pages/__tests__/CoopDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/CoopDetailPage.test.tsx
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ToastContext, type ToastContextType } from '../../contexts/ToastContext';
+import { CoopDetailPage } from '../CoopDetailPage';
+
+// Capture what gets set on the AppBar
+const mockSetAppBar = vi.fn();
+const mockResetAppBar = vi.fn();
+
+vi.mock('../../context/AppBarContext', async () => {
+  const actual = await vi.importActual('../../context/AppBarContext');
+  return {
+    ...actual,
+    useAppBar: () => ({
+      title: null,
+      onBack: null,
+      setAppBar: mockSetAppBar,
+      resetAppBar: mockResetAppBar,
+    }),
+  };
+});
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const map: Record<string, string> = {
+        'coops.details': 'Coop Details',
+        'coops.title': 'Coops',
+        'coops.coopName': 'Coop Name',
+        'coops.location': 'Location',
+        'coops.status': 'Status',
+        'coops.active': 'Active',
+        'coops.archived': 'Archived',
+        'coops.createdAt': 'Created At',
+        'coops.updatedAt': 'Updated At',
+        'coops.archiveCoop': 'Archive',
+        'coops.archiveSuccess': 'Archived!',
+        'coops.deleteSuccess': 'Deleted!',
+        'coops.deleteErrorHasFlocks': 'Has flocks',
+        'coops.coopNotFound': 'Not found',
+        'common.edit': 'Edit',
+        'common.delete': 'Delete',
+        'errors.backToList': 'Back to list',
+        'flocks.title': 'Flocks',
+      };
+      return map[key] ?? key;
+    },
+  }),
+}));
+
+vi.mock('../../features/coops/hooks/useCoopDetail', () => ({
+  useCoopDetail: vi.fn(() => ({
+    data: {
+      id: 'coop-1',
+      name: 'Test Coop',
+      location: 'Farm A',
+      isActive: true,
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-01T00:00:00Z',
+      flocksCount: 0,
+    },
+    isLoading: false,
+    error: null,
+  })),
+}));
+
+vi.mock('../../features/coops/hooks/useCoops', () => ({
+  useArchiveCoop: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useDeleteCoop: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+}));
+
+vi.mock('../../hooks/useErrorHandler', () => ({
+  useErrorHandler: () => ({ handleError: vi.fn() }),
+}));
+
+vi.mock('../../features/coops/components/EditCoopModal', () => ({
+  EditCoopModal: () => null,
+}));
+vi.mock('../../features/coops/components/ArchiveCoopDialog', () => ({
+  ArchiveCoopDialog: () => null,
+}));
+vi.mock('../../features/coops/components/DeleteCoopDialog', () => ({
+  DeleteCoopDialog: () => null,
+}));
+vi.mock('../../components/ResourceNotFound', () => ({
+  ResourceNotFound: ({ translationKey }: { translationKey: string }) => (
+    <div data-testid="resource-not-found">{translationKey}</div>
+  ),
+}));
+vi.mock('../../shared/components', () => ({
+  CoopDetailSkeleton: () => <div data-testid="skeleton" />,
+}));
+
+const mockToast: ToastContextType = {
+  showToast: vi.fn(),
+  showError: vi.fn(),
+  showSuccess: vi.fn(),
+  showWarning: vi.fn(),
+  showInfo: vi.fn(),
+  hideToast: vi.fn(),
+};
+
+function renderPage() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ToastContext.Provider value={mockToast}>
+        <MemoryRouter initialEntries={['/coops/coop-1']}>
+          <Routes>
+            <Route path="/coops/:id" element={<CoopDetailPage />} />
+          </Routes>
+        </MemoryRouter>
+      </ToastContext.Provider>
+    </QueryClientProvider>
+  );
+}
+
+describe('CoopDetailPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls setAppBar with coop name and onBack when data loads', () => {
+    renderPage();
+    expect(mockSetAppBar).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Test Coop', onBack: expect.any(Function) })
+    );
+  });
+
+  it('calls resetAppBar on unmount', () => {
+    const { unmount } = renderPage();
+    unmount();
+    expect(mockResetAppBar).toHaveBeenCalled();
+  });
+
+  it('renders coop name in the detail card', () => {
+    renderPage();
+    expect(screen.getByText('Test Coop')).toBeInTheDocument();
+  });
+
+  it('does not render an inline back button inside the page', () => {
+    renderPage();
+    // No ArrowBack IconButton should be in the page content
+    const backButtons = screen.queryAllByRole('button', { name: /back/i });
+    expect(backButtons).toHaveLength(0);
+  });
+
+  it('renders action buttons', () => {
+    renderPage();
+    expect(screen.getByText('Edit')).toBeInTheDocument();
+    expect(screen.getByText('Archive')).toBeInTheDocument();
+    expect(screen.getByText('Delete')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/__tests__/FlockDetailPage.test.tsx
+++ b/frontend/src/pages/__tests__/FlockDetailPage.test.tsx
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ToastContext, type ToastContextType } from '../../contexts/ToastContext';
+import { FlockDetailPage } from '../FlockDetailPage';
+
+const mockSetAppBar = vi.fn();
+const mockResetAppBar = vi.fn();
+
+vi.mock('../../context/AppBarContext', async () => {
+  const actual = await vi.importActual('../../context/AppBarContext');
+  return {
+    ...actual,
+    useAppBar: () => ({
+      title: null,
+      onBack: null,
+      setAppBar: mockSetAppBar,
+      resetAppBar: mockResetAppBar,
+    }),
+  };
+});
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const map: Record<string, string> = {
+        'flocks.details': 'Flock Details',
+        'flocks.title': 'Flocks',
+        'flocks.identifier': 'Identifier',
+        'flocks.status': 'Status',
+        'flocks.active': 'Active',
+        'flocks.hatchDate': 'Hatch Date',
+        'flocks.currentComposition': 'Composition',
+        'flocks.hens': 'Hens',
+        'flocks.roosters': 'Roosters',
+        'flocks.chicks': 'Chicks',
+        'flocks.total': 'Total',
+        'flocks.createdAt': 'Created At',
+        'flocks.updatedAt': 'Updated At',
+        'flocks.archiveFlock': 'Archive',
+        'flocks.archiveSuccess': 'Archived!',
+        'flocks.viewHistory': 'History',
+        'flocks.flockNotFound': 'Not found',
+        'flocks.matureChicks.action': 'Mature Chicks',
+        'flocks.matureChicks.disabledInactive': 'Inactive',
+        'flocks.matureChicks.disabledNoChicks': 'No chicks',
+        'common.edit': 'Edit',
+        'errors.backToList': 'Back to list',
+      };
+      return map[key] ?? key;
+    },
+  }),
+}));
+
+vi.mock('../../features/flocks/hooks/useFlocks', () => ({
+  useFlockDetail: vi.fn(() => ({
+    data: {
+      id: 'flock-1',
+      coopId: 'coop-1',
+      identifier: 'Flock A',
+      isActive: true,
+      hatchDate: null,
+      currentHens: 5,
+      currentRoosters: 1,
+      currentChicks: 0,
+      createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-01T00:00:00Z',
+    },
+    isLoading: false,
+    error: null,
+  })),
+  useArchiveFlock: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+}));
+
+vi.mock('../../hooks/useErrorHandler', () => ({
+  useErrorHandler: () => ({ handleError: vi.fn() }),
+}));
+
+vi.mock('../../features/flocks/components/EditFlockModal', () => ({
+  EditFlockModal: () => null,
+}));
+vi.mock('../../features/flocks/components/ArchiveFlockDialog', () => ({
+  ArchiveFlockDialog: () => null,
+}));
+vi.mock('../../features/flocks/components/MatureChicksModal', () => ({
+  MatureChicksModal: () => null,
+}));
+vi.mock('../../components/ResourceNotFound', () => ({
+  ResourceNotFound: ({ translationKey }: { translationKey: string }) => (
+    <div data-testid="resource-not-found">{translationKey}</div>
+  ),
+}));
+vi.mock('../../shared/components', () => ({
+  CoopDetailSkeleton: () => <div data-testid="skeleton" />,
+  StatCard: ({ label, value }: { label: string; value: number }) => (
+    <div>{label}: {value}</div>
+  ),
+}));
+
+const mockToast: ToastContextType = {
+  showToast: vi.fn(),
+  showError: vi.fn(),
+  showSuccess: vi.fn(),
+  showWarning: vi.fn(),
+  showInfo: vi.fn(),
+  hideToast: vi.fn(),
+};
+
+function renderPage() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ToastContext.Provider value={mockToast}>
+        <MemoryRouter initialEntries={['/coops/coop-1/flocks/flock-1']}>
+          <Routes>
+            <Route path="/coops/:coopId/flocks/:flockId" element={<FlockDetailPage />} />
+          </Routes>
+        </MemoryRouter>
+      </ToastContext.Provider>
+    </QueryClientProvider>
+  );
+}
+
+describe('FlockDetailPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls setAppBar with flock identifier and onBack when data loads', () => {
+    renderPage();
+    expect(mockSetAppBar).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Flock A', onBack: expect.any(Function) })
+    );
+  });
+
+  it('calls resetAppBar on unmount', () => {
+    const { unmount } = renderPage();
+    unmount();
+    expect(mockResetAppBar).toHaveBeenCalled();
+  });
+
+  it('renders flock identifier in the detail card', () => {
+    renderPage();
+    expect(screen.getByText('Flock A')).toBeInTheDocument();
+  });
+
+  it('does not render an inline back button inside the page', () => {
+    renderPage();
+    const backButtons = screen.queryAllByRole('button', { name: /back/i });
+    expect(backButtons).toHaveLength(0);
+  });
+
+  it('renders action buttons', () => {
+    renderPage();
+    expect(screen.getByText('Edit')).toBeInTheDocument();
+    expect(screen.getByText('Archive')).toBeInTheDocument();
+    expect(screen.getByText('History')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #53

- Introduced `AppBarContext` — pages can call `setAppBar({ title, onBack })` to control the top AppBar
- Restructured `App.tsx` into `AppBarProvider` + `AppInner` so the MUI AppBar and route pages share the same context
- `CoopDetailPage`: sets dynamic title (coop name) and back handler; inline back button removed
- `FlockDetailPage`: same pattern (flock identifier as title)
- `FlockHistoryPage`: rewritten to use AppBar context, inline Box header removed
- AppBar shows ArrowBack icon when `onBack` is set, AccountCircle icon otherwise

## Tests

- `AppBarContext` — 6 unit tests (defaults, setAppBar, resetAppBar, merge, outside provider)
- `CoopDetailPage` — 5 tests
- `FlockDetailPage` — 5 tests
- `FlockHistoryPage` — 4 tests

All 20 tests pass.