### PR TITLE
fix: FAB always visible with disabled state when no flocks exist

### DIFF
--- a/frontend/src/locales/cs/translation.json
+++ b/frontend/src/locales/cs/translation.json
@@ -527,5 +527,9 @@
       "dismiss": "Už nezobrazovat",
       "gotIt": "Rozumím"
     }
+  },
+  "fab": {
+    "addRecord": "Přidat denní záznam",
+    "disabledTooltip": "Nejprve přidejte hejno"
   }
 }

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -525,5 +525,9 @@
       "dismiss": "Don't show again",
       "gotIt": "Got it"
     }
+  },
+  "fab": {
+    "addRecord": "Add daily record",
+    "disabledTooltip": "Add a flock first"
   }
 }

--- a/frontend/src/pages/DailyRecordsListPage.tsx
+++ b/frontend/src/pages/DailyRecordsListPage.tsx
@@ -313,12 +313,12 @@ export function DailyRecordsListPage() {
       )}
 
       {/* Floating Action Button - Add Daily Record */}
-      <Tooltip title={t('dailyRecords.addRecord')} placement="left">
+      <Tooltip title={flocks.length === 0 ? t('fab.disabledTooltip') : t('fab.addRecord')} placement="left">
         <span>
           <Fab
             color="primary"
-            aria-label={t('dailyRecords.addRecord')}
-            onClick={() => setIsQuickAddOpen(true)}
+            aria-label={t('fab.addRecord')}
+            onClick={flocks.length > 0 ? () => setIsQuickAddOpen(true) : undefined}
             disabled={flocks.length === 0}
             sx={{
               position: 'fixed',

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -96,25 +96,23 @@ export default function DashboardPage() {
         )}
 
         {/* Floating Action Button - Add Daily Record */}
-        {hasData && (
-          <Tooltip title={t('dashboard.quickActions.addDailyRecord')} placement="left">
-            <span>
-              <Fab
-                color="primary"
-                aria-label={t('dashboard.quickActions.addDailyRecordAriaLabel')}
-                onClick={handleAddDailyRecord}
-                disabled={flocks.length === 0}
-                sx={{
-                  position: 'fixed',
-                  bottom: { xs: 'calc(env(safe-area-inset-bottom) + 80px)', sm: 24 },
-                  right: 16,
-                }}
-              >
-                <AddIcon />
-              </Fab>
-            </span>
-          </Tooltip>
-        )}
+        <Tooltip title={!hasData ? t('fab.disabledTooltip') : t('fab.addRecord')} placement="left">
+          <span>
+            <Fab
+              color="primary"
+              aria-label={t('fab.addRecord')}
+              onClick={hasData ? handleAddDailyRecord : undefined}
+              disabled={!hasData}
+              sx={{
+                position: 'fixed',
+                bottom: { xs: 'calc(env(safe-area-inset-bottom) + 80px)', sm: 24 },
+                right: 16,
+              }}
+            >
+              <AddIcon />
+            </Fab>
+          </span>
+        </Tooltip>
 
         {/* Quick Add Modal */}
         <QuickAddModal

--- a/frontend/src/pages/__tests__/DailyRecordsListPage.test.tsx
+++ b/frontend/src/pages/__tests__/DailyRecordsListPage.test.tsx
@@ -70,6 +70,8 @@ vi.mock('react-i18next', () => ({
     t: (key: string, params?: Record<string, unknown>) => {
       const translations: Record<string, string> = {
         'dailyRecords.title': 'Daily Records',
+        'fab.addRecord': 'Add Record',
+        'fab.disabledTooltip': 'Add a flock first',
         'dailyRecords.addRecord': 'Add Record',
         'dailyRecords.flock': 'Flock',
         'dailyRecords.clearFilters': 'Clear filters',

--- a/frontend/src/pages/__tests__/DashboardPage.test.tsx
+++ b/frontend/src/pages/__tests__/DashboardPage.test.tsx
@@ -83,9 +83,11 @@ describe('DashboardPage', () => {
       expect(screen.queryByText('dashboard.quickActions.viewStatistics')).not.toBeInTheDocument();
     });
 
-    it('renders the FAB', () => {
+    it('renders the FAB enabled', () => {
       renderPage();
-      expect(screen.getByRole('button', { name: 'dashboard.quickActions.addDailyRecordAriaLabel' })).toBeInTheDocument();
+      const fab = screen.getByRole('button', { name: 'fab.addRecord' });
+      expect(fab).toBeInTheDocument();
+      expect(fab).not.toBeDisabled();
     });
 
     it('does not render empty state', () => {
@@ -114,9 +116,11 @@ describe('DashboardPage', () => {
       expect(screen.queryByTestId('today-summary-widget')).not.toBeInTheDocument();
     });
 
-    it('does not render FAB', () => {
+    it('renders the FAB disabled', () => {
       renderPage();
-      expect(screen.queryByRole('button', { name: 'dashboard.quickActions.addDailyRecordAriaLabel' })).not.toBeInTheDocument();
+      const fab = screen.getByRole('button', { name: 'fab.addRecord' });
+      expect(fab).toBeInTheDocument();
+      expect(fab).toBeDisabled();
     });
   });
 


### PR DESCRIPTION
## Summary

- FAB on DashboardPage is now always rendered instead of conditionally hidden
- FAB shows disabled state when user has no active flocks/data
- Tooltip shows disabled message when no data, add record otherwise
- Same pattern applied to DailyRecordsListPage for consistency

## Changes

- `frontend/src/pages/DashboardPage.tsx` — FAB always rendered, disabled when no data
- `frontend/src/pages/DailyRecordsListPage.tsx` — updated aria-label and tooltip to use fab.* keys
- `frontend/src/locales/en/translation.json` — added fab.addRecord and fab.disabledTooltip
- `frontend/src/locales/cs/translation.json` — added Czech translations for fab keys
- `frontend/src/pages/__tests__/DashboardPage.test.tsx` — updated tests for new FAB behavior
- `frontend/src/pages/__tests__/DailyRecordsListPage.test.tsx` — added fab.* keys to translations mock

## Tests

All 734 tests pass.

Closes #54