### PR TITLE
fix: invalidate dashboard stats after flock operations

### DIFF
--- a/frontend/src/features/flocks/hooks/__tests__/useFlocks.test.ts
+++ b/frontend/src/features/flocks/hooks/__tests__/useFlocks.test.ts
@@ -98,6 +98,25 @@ describe('useCreateFlock', () => {
     expect(invalidatedFlat).toContain(JSON.stringify({ queryKey: ['flocks', 'all'] }));
   });
 
+  it('invalidates ["dashboard", "stats"] after successful creation', async () => {
+    mockCreate.mockResolvedValue({ id: 'flock-1', coopId: 'coop-1', identifier: 'F1', hatchDate: '2024-01-01', currentHens: 10, currentRoosters: 1, currentChicks: 0, isActive: true, createdAt: '', updatedAt: '', history: [], tenantId: 't1' });
+
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useCreateFlock(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      result.current.mutate({ coopId: 'coop-1', identifier: 'F1', hatchDate: '2024-01-01', initialHens: 10, initialRoosters: 1, initialChicks: 0 });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const invalidatedKeys = invalidateSpy.mock.calls.map((call) => JSON.stringify(call[0]));
+    expect(invalidatedKeys).toContain(JSON.stringify({ queryKey: ['dashboard', 'stats'] }));
+  });
+
   it('invalidates scoped coop key after successful creation', async () => {
     mockCreate.mockResolvedValue({ id: 'flock-1', coopId: 'coop-1', identifier: 'F1', hatchDate: '2024-01-01', currentHens: 10, currentRoosters: 1, currentChicks: 0, isActive: true, createdAt: '', updatedAt: '', history: [], tenantId: 't1' });
 
@@ -221,6 +240,25 @@ describe('useArchiveFlock', () => {
 
     const invalidatedKeys = invalidateSpy.mock.calls.map((call) => JSON.stringify(call[0]));
     expect(invalidatedKeys).toContain(JSON.stringify({ queryKey: ['flocks', 'all'] }));
+  });
+
+  it('invalidates ["dashboard", "stats"] after successful archive', async () => {
+    mockArchive.mockResolvedValue(undefined);
+
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useArchiveFlock(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      result.current.mutate({ coopId: 'coop-1', flockId: 'flock-1' });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const invalidatedKeys = invalidateSpy.mock.calls.map((call) => JSON.stringify(call[0]));
+    expect(invalidatedKeys).toContain(JSON.stringify({ queryKey: ['dashboard', 'stats'] }));
   });
 
   it('invalidates coop-scoped and flock-specific keys after successful archive', async () => {

--- a/frontend/src/features/flocks/hooks/useFlocks.ts
+++ b/frontend/src/features/flocks/hooks/useFlocks.ts
@@ -107,6 +107,10 @@ export function useCreateFlock() {
       queryClient.invalidateQueries({
         queryKey: ['flocks', 'all']
       });
+      // Dashboard stats depend on flock counts — invalidate so the summary page refreshes
+      queryClient.invalidateQueries({
+        queryKey: ['dashboard', 'stats']
+      });
     },
   });
 }
@@ -167,6 +171,7 @@ export function useMatureChicks() {
     onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: ['flocks'] });
       queryClient.invalidateQueries({ queryKey: ['flockHistory', variables.flockId] });
+      queryClient.invalidateQueries({ queryKey: ['dashboard', 'stats'] });
       showSuccess(
         t('flocks.matureChicks.success'),
         'flocks.matureChicks.success'
@@ -202,6 +207,9 @@ export function useArchiveFlock() {
       });
       queryClient.invalidateQueries({
         queryKey: ['flocks', 'all']
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['dashboard', 'stats']
       });
       showSuccess(
         t('flocks.archive.success'),


### PR DESCRIPTION
## Summary

- After creating the first flock on an empty DB, navigating to the dashboard still showed the blank placeholder because the `["dashboard", "stats"]` React Query cache was never invalidated
- Same issue applies when archiving a flock or maturing chicks (both change the counts shown on the dashboard)

## Changes

- `frontend/src/features/flocks/hooks/useFlocks.ts`: Added `queryClient.invalidateQueries({ queryKey: ["dashboard", "stats"] })` to the `onSettled` handler of `useCreateFlock`, and to the `onSuccess` handlers of `useArchiveFlock` and `useMatureChicks`
- `frontend/src/features/flocks/hooks/__tests__/useFlocks.test.ts`: Added tests verifying that `["dashboard", "stats"]` is invalidated after flock creation and after archiving a flock

## Tests

Added 2 new tests:
- `useCreateFlock` → `invalidates ["dashboard", "stats"] after successful creation`
- `useArchiveFlock` → `invalidates ["dashboard", "stats"] after successful archive`

All 777 frontend tests pass.

Closes #65