### PR TITLE
fix: resolve three flock update failures on production (#70)

### DIFF
--- a/backend/src/Chickquita.Api/Program.cs
+++ b/backend/src/Chickquita.Api/Program.cs
@@ -1,6 +1,7 @@
 using Chickquita.Api.Endpoints;
 using Chickquita.Api.Middleware;
 using Chickquita.Application;
+using FluentValidation;
 using MediatR;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -106,6 +107,30 @@ if (builder.Environment.IsDevelopment())
 }
 
 var app = builder.Build();
+
+// Intercept FluentValidation.ValidationException from the MediatR pipeline behavior
+// and return 400 Bad Request instead of 500. This applies to all endpoints globally.
+app.Use(async (context, next) =>
+{
+    try
+    {
+        await next(context);
+    }
+    catch (ValidationException ex)
+    {
+        context.Response.StatusCode = StatusCodes.Status400BadRequest;
+        context.Response.ContentType = "application/json";
+        var error = new
+        {
+            error = new
+            {
+                code = "Error.Validation",
+                message = string.Join("; ", ex.Errors.Select(e => e.ErrorMessage))
+            }
+        };
+        await context.Response.WriteAsJsonAsync(error);
+    }
+});
 
 // Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())

--- a/backend/src/Chickquita.Application/Behaviors/ValidationBehavior.cs
+++ b/backend/src/Chickquita.Application/Behaviors/ValidationBehavior.cs
@@ -1,0 +1,85 @@
+using System.Reflection;
+using Chickquita.Domain.Common;
+using FluentValidation;
+using MediatR;
+
+namespace Chickquita.Application.Behaviors;
+
+/// <summary>
+/// MediatR pipeline behavior that runs FluentValidation validators before the handler is invoked.
+///
+/// When <typeparamref name="TResponse"/> is <see cref="Result{T}"/>, validation failures are
+/// returned as <c>Result&lt;T&gt;.Failure(Error.Validation(...))</c> so callers receive a
+/// consistent result object rather than a thrown exception.
+///
+/// For other response types a <see cref="ValidationException"/> is thrown, which is caught by
+/// the global exception handler middleware in the API layer.
+/// </summary>
+/// <typeparam name="TRequest">The request type.</typeparam>
+/// <typeparam name="TResponse">The response type.</typeparam>
+public sealed class ValidationBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : notnull
+{
+    private readonly IEnumerable<IValidator<TRequest>> _validators;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ValidationBehavior{TRequest, TResponse}"/> class.
+    /// </summary>
+    /// <param name="validators">All registered validators for <typeparamref name="TRequest"/>.</param>
+    public ValidationBehavior(IEnumerable<IValidator<TRequest>> validators)
+    {
+        _validators = validators;
+    }
+
+    /// <inheritdoc />
+    public async Task<TResponse> Handle(
+        TRequest request,
+        RequestHandlerDelegate<TResponse> next,
+        CancellationToken cancellationToken)
+    {
+        if (!_validators.Any())
+        {
+            return await next();
+        }
+
+        var context = new ValidationContext<TRequest>(request);
+
+        var failures = _validators
+            .Select(v => v.Validate(context))
+            .SelectMany(r => r.Errors)
+            .Where(f => f is not null)
+            .ToList();
+
+        if (failures.Count == 0)
+        {
+            return await next();
+        }
+
+        var errorMessage = string.Join("; ", failures.Select(f => f.ErrorMessage));
+        var error = Error.Validation(errorMessage);
+
+        // When TResponse is Result<T>, return a failure result so callers get a consistent
+        // Result object rather than a thrown exception. This preserves the pattern used
+        // throughout the application where handlers return Result<T>.
+        var responseType = typeof(TResponse);
+        if (responseType.IsGenericType &&
+            responseType.GetGenericTypeDefinition() == typeof(Result<>))
+        {
+            // Use the implicit Error → Result<T> conversion operator
+            var implicitOp = responseType.GetMethod(
+                "op_Implicit",
+                BindingFlags.Public | BindingFlags.Static,
+                binder: null,
+                types: new[] { typeof(Error) },
+                modifiers: null);
+
+            if (implicitOp is not null)
+            {
+                return (TResponse)implicitOp.Invoke(null, new object[] { error })!;
+            }
+        }
+
+        // Fallback: throw for non-Result response types (caught by the API exception middleware)
+        throw new ValidationException(failures);
+    }
+}

--- a/backend/src/Chickquita.Application/DependencyInjection.cs
+++ b/backend/src/Chickquita.Application/DependencyInjection.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Chickquita.Application.Behaviors;
 using FluentValidation;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
@@ -17,10 +18,11 @@ public static class DependencyInjection
     /// <returns>The service collection for chaining</returns>
     public static IServiceCollection AddApplicationServices(this IServiceCollection services)
     {
-        // Register MediatR with all handlers from this assembly
+        // Register MediatR with all handlers and the validation pipeline behavior
         services.AddMediatR(cfg =>
         {
             cfg.RegisterServicesFromAssembly(Assembly.GetExecutingAssembly());
+            cfg.AddBehavior(typeof(IPipelineBehavior<,>), typeof(ValidationBehavior<,>));
         });
 
         // Register AutoMapper with profiles from this assembly

--- a/backend/src/Chickquita.Infrastructure/Repositories/FlockRepository.cs
+++ b/backend/src/Chickquita.Infrastructure/Repositories/FlockRepository.cs
@@ -88,7 +88,39 @@ public class FlockRepository : IFlockRepository
             throw new ArgumentNullException(nameof(flock));
         }
 
-        _context.Flocks.Update(flock);
+        var entry = _context.Entry(flock);
+        if (entry.State == EntityState.Detached)
+        {
+            // Entity was not loaded by this context (e.g. came from a previous scope).
+            // Calling Update() walks the entity graph via TrackGraph and marks everything
+            // as Modified so SaveChanges generates the correct UPDATE statements.
+            _context.Flocks.Update(flock);
+        }
+        else
+        {
+            // Entity is already tracked by this context (loaded via GetByIdWithoutHistoryAsync).
+            // EF Core's snapshot change tracker detects property mutations automatically.
+            //
+            // When a new FlockHistory entry is added via UpdateComposition, EF Core's internal
+            // observable collection for History immediately fires a CollectionChanged event.
+            // The fix-up handler tracks the new entity — but because it has a non-default GUID
+            // key, EF Core assumes the entity already exists in the DB and marks it Modified
+            // rather than Added. SaveChanges then generates UPDATE instead of INSERT, which
+            // affects 0 rows (the row doesn't exist yet) and throws DbUpdateConcurrencyException.
+            //
+            // Fix: correct the state from Modified to Added for each entry currently in
+            // flock.History. These are all new entities added since the flock was loaded
+            // (GetByIdWithoutHistoryAsync loads without history, so the collection starts empty).
+            foreach (var historyItem in flock.History)
+            {
+                var historyEntry = _context.Entry(historyItem);
+                if (historyEntry.State == EntityState.Modified)
+                {
+                    historyEntry.State = EntityState.Added;
+                }
+            }
+        }
+
         await _context.SaveChangesAsync();
 
         return flock;

--- a/backend/tests/Chickquita.Application.Tests/Behaviors/ValidationBehaviorTests.cs
+++ b/backend/tests/Chickquita.Application.Tests/Behaviors/ValidationBehaviorTests.cs
@@ -1,0 +1,115 @@
+using Chickquita.Application.Behaviors;
+using Chickquita.Domain.Common;
+using FluentAssertions;
+using FluentValidation;
+using MediatR;
+using Moq;
+
+namespace Chickquita.Application.Tests.Behaviors;
+
+/// <summary>
+/// Unit tests for ValidationBehavior.
+/// Verifies that the pipeline behavior invokes registered validators and returns
+/// Result failure or throws ValidationException on validation failures.
+/// </summary>
+public class ValidationBehaviorTests
+{
+    private record TestRequest(string Value) : IRequest<string>;
+    private record ResultRequest(string Value) : IRequest<Result<string>>;
+
+    private class TestRequestValidator : AbstractValidator<TestRequest>
+    {
+        public TestRequestValidator()
+        {
+            RuleFor(x => x.Value)
+                .NotEmpty()
+                .WithMessage("Value is required.");
+        }
+    }
+
+    private class ResultRequestValidator : AbstractValidator<ResultRequest>
+    {
+        public ResultRequestValidator()
+        {
+            RuleFor(x => x.Value)
+                .NotEmpty()
+                .WithMessage("Value is required.");
+        }
+    }
+
+    [Fact]
+    public async Task Handle_WithNoValidators_ShouldCallNext()
+    {
+        // Arrange
+        var behavior = new ValidationBehavior<TestRequest, string>(
+            Enumerable.Empty<IValidator<TestRequest>>());
+
+        var nextMock = new Mock<RequestHandlerDelegate<string>>();
+        nextMock.Setup(n => n()).ReturnsAsync("ok");
+
+        // Act
+        var result = await behavior.Handle(new TestRequest("some value"), nextMock.Object, CancellationToken.None);
+
+        // Assert
+        result.Should().Be("ok");
+        nextMock.Verify(n => n(), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WithValidRequest_ShouldCallNext()
+    {
+        // Arrange
+        var behavior = new ValidationBehavior<TestRequest, string>(
+            new[] { new TestRequestValidator() });
+
+        var nextMock = new Mock<RequestHandlerDelegate<string>>();
+        nextMock.Setup(n => n()).ReturnsAsync("ok");
+
+        // Act
+        var result = await behavior.Handle(new TestRequest("valid value"), nextMock.Object, CancellationToken.None);
+
+        // Assert
+        result.Should().Be("ok");
+        nextMock.Verify(n => n(), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WithInvalidRequest_NonResultResponse_ShouldThrowValidationException()
+    {
+        // Arrange: non-Result TResponse falls back to throwing
+        var behavior = new ValidationBehavior<TestRequest, string>(
+            new[] { new TestRequestValidator() });
+
+        var nextMock = new Mock<RequestHandlerDelegate<string>>();
+
+        // Act
+        Func<Task> act = async () =>
+            await behavior.Handle(new TestRequest(string.Empty), nextMock.Object, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ValidationException>()
+            .WithMessage("*Value is required*");
+
+        nextMock.Verify(n => n(), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WithInvalidRequest_ResultResponse_ShouldReturnFailureResult()
+    {
+        // Arrange: Result<T> response returns failure instead of throwing
+        var behavior = new ValidationBehavior<ResultRequest, Result<string>>(
+            new[] { new ResultRequestValidator() });
+
+        var nextMock = new Mock<RequestHandlerDelegate<Result<string>>>();
+
+        // Act
+        var result = await behavior.Handle(new ResultRequest(string.Empty), nextMock.Object, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Error.Validation");
+        result.Error.Message.Should().Contain("Value is required");
+
+        nextMock.Verify(n => n(), Times.Never);
+    }
+}

--- a/backend/tests/Chickquita.Infrastructure.Tests/Repositories/FlockRepositoryTests.cs
+++ b/backend/tests/Chickquita.Infrastructure.Tests/Repositories/FlockRepositoryTests.cs
@@ -1,0 +1,180 @@
+using Chickquita.Application.Interfaces;
+using Chickquita.Domain.Entities;
+using Chickquita.Infrastructure.Data;
+using Chickquita.Infrastructure.Repositories;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+
+namespace Chickquita.Infrastructure.Tests.Repositories;
+
+/// <summary>
+/// Integration tests for FlockRepository.
+/// Uses SQLite in-memory database to verify that UpdateAsync correctly handles
+/// EF Core change tracking, especially for FlockHistory child entities.
+///
+/// Each test uses a fresh DbContext per operation to mirror real request-scoped usage
+/// and avoid EF Core identity-map interference.
+/// </summary>
+public class FlockRepositoryTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<ApplicationDbContext> _options;
+    private readonly Guid _tenantId;
+    private readonly Guid _coopId;
+
+    public FlockRepositoryTests()
+    {
+        // Keep the connection open for the lifetime of the test so in-memory DB persists
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        _options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+
+        _tenantId = Guid.NewGuid();
+
+        // Seed tenant and coop using a setup context
+        using var setupContext = CreateContext();
+        setupContext.Database.EnsureCreated();
+
+        var tenant = Tenant.Create("clerk_user_test", "test@example.com");
+        typeof(Tenant).GetProperty(nameof(Tenant.Id))!.SetValue(tenant, _tenantId);
+        setupContext.Tenants.Add(tenant);
+
+        var coop = Coop.Create(_tenantId, "Test Coop", null);
+        setupContext.Coops.Add(coop);
+        setupContext.SaveChanges();
+        _coopId = coop.Id;
+    }
+
+    public void Dispose()
+    {
+        _connection.Dispose();
+    }
+
+    /// <summary>Creates a fresh DbContext that scopes to _tenantId.</summary>
+    private ApplicationDbContext CreateContext()
+    {
+        var mockCurrentUser = new Mock<ICurrentUserService>();
+        mockCurrentUser.Setup(x => x.TenantId).Returns(_tenantId);
+        return new ApplicationDbContext(_options, mockCurrentUser.Object);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_WhenEntityIsTracked_ShouldSaveChangesWithoutConflict()
+    {
+        // Arrange: persist a flock in a dedicated context
+        var flockId = Guid.Empty;
+        using (var ctx = CreateContext())
+        {
+            var repo = new FlockRepository(ctx);
+            var flock = Flock.Create(_tenantId, _coopId, "Original", DateTime.UtcNow.AddDays(-30), 10, 2, 0);
+            await repo.AddAsync(flock);
+            flockId = flock.Id;
+        }
+
+        // Act: load and update in a fresh context (simulating a new request)
+        using (var ctx = CreateContext())
+        {
+            var repo = new FlockRepository(ctx);
+            var trackedFlock = await repo.GetByIdWithoutHistoryAsync(flockId);
+            trackedFlock.Should().NotBeNull();
+
+            trackedFlock!.Update("Updated Name", DateTime.UtcNow.AddDays(-20));
+
+            // UpdateAsync should detect the entity is already tracked and skip Update()
+            var result = await repo.UpdateAsync(trackedFlock);
+            result.Identifier.Should().Be("Updated Name");
+        }
+
+        // Verify persisted in a third context
+        using (var ctx = CreateContext())
+        {
+            var repo = new FlockRepository(ctx);
+            var persisted = await repo.GetByIdWithoutHistoryAsync(flockId);
+            persisted.Should().NotBeNull();
+            persisted!.Identifier.Should().Be("Updated Name");
+        }
+    }
+
+    [Fact]
+    public async Task UpdateAsync_WhenCompositionChanges_ShouldPersistNewHistoryEntry()
+    {
+        // Arrange: persist a flock with initial composition (creates 1 history entry)
+        var flockId = Guid.Empty;
+        using (var ctx = CreateContext())
+        {
+            var repo = new FlockRepository(ctx);
+            var flock = Flock.Create(_tenantId, _coopId, "Test Flock", DateTime.UtcNow.AddDays(-60), 10, 2, 5);
+            await repo.AddAsync(flock);
+            flockId = flock.Id;
+        }
+
+        // Act: load without history and update composition in a fresh context
+        // This mirrors UpdateFlockCommandHandler's behavior exactly
+        using (var ctx = CreateContext())
+        {
+            var repo = new FlockRepository(ctx);
+            var trackedFlock = await repo.GetByIdWithoutHistoryAsync(flockId);
+            trackedFlock.Should().NotBeNull();
+
+            // Simulate composition update — adds a new FlockHistory to the tracked collection
+            trackedFlock!.UpdateComposition(12, 2, 5, "Manual update");
+
+            await repo.UpdateAsync(trackedFlock);
+        }
+
+        // Assert: new history entry must be persisted
+        using (var ctx = CreateContext())
+        {
+            var repo = new FlockRepository(ctx);
+            var updated = await repo.GetByIdAsync(flockId);
+            updated.Should().NotBeNull();
+            updated!.CurrentHens.Should().Be(12);
+
+            // Should have initial entry + new composition entry = 2 total
+            updated.History.Should().HaveCount(2);
+        }
+    }
+
+    [Fact]
+    public async Task UpdateAsync_WhenEntityIsDetached_ShouldStillSaveChanges()
+    {
+        // Arrange: persist a flock in a dedicated context
+        var flockId = Guid.Empty;
+        Flock? detachedFlock = null;
+        using (var ctx = CreateContext())
+        {
+            var repo = new FlockRepository(ctx);
+            var flock = Flock.Create(_tenantId, _coopId, "Detached Flock", DateTime.UtcNow.AddDays(-30), 5, 1, 0);
+            await repo.AddAsync(flock);
+            flockId = flock.Id;
+            detachedFlock = flock;
+        }
+        // After the context is disposed, the entity is effectively detached from any context
+
+        // Act: update the entity via a fresh context where it is not yet tracked
+        using (var ctx = CreateContext())
+        {
+            var repo = new FlockRepository(ctx);
+            // Verify the entity is not tracked by this context (state = Detached)
+            ctx.Entry(detachedFlock!).State.Should().Be(EntityState.Detached);
+
+            detachedFlock.Update("Detached Updated", DateTime.UtcNow.AddDays(-10));
+            var result = await repo.UpdateAsync(detachedFlock);
+            result.Identifier.Should().Be("Detached Updated");
+        }
+
+        // Verify persisted
+        using (var ctx = CreateContext())
+        {
+            var repo = new FlockRepository(ctx);
+            var persisted = await repo.GetByIdWithoutHistoryAsync(flockId);
+            persisted.Should().NotBeNull();
+            persisted!.Identifier.Should().Be("Detached Updated");
+        }
+    }
+}

--- a/frontend/src/features/flocks/hooks/useFlocks.ts
+++ b/frontend/src/features/flocks/hooks/useFlocks.ts
@@ -122,7 +122,7 @@ export function useCreateFlock() {
 export function useUpdateFlock() {
   const queryClient = useQueryClient();
   const { t } = useTranslation();
-  const { showSuccess, showError } = useToast();
+  const { showSuccess } = useToast();
 
   return useMutation({
     mutationFn: ({
@@ -145,12 +145,6 @@ export function useUpdateFlock() {
       showSuccess(
         t('flocks.update.success'),
         'flocks.update.success'
-      );
-    },
-    onError: () => {
-      showError(
-        t('flocks.update.error'),
-        'flocks.update.error'
       );
     },
   });


### PR DESCRIPTION
## Summary

Fixes #70 - three distinct bugs causing flock update failures on production:

- **Bug 1 (double toast)**: Removed global `onError` handler from `useUpdateFlock`. The per-call `onError` in `EditFlockModal` already handles both validation and generic errors — the hook-level handler was firing a duplicate toast on every error.

- **Bug 2 (validator never invoked)**: Added `ValidationBehavior<TRequest, TResponse>` as a MediatR pipeline behavior. Registers all FluentValidation validators to run before any handler. Returns `Result<T>.Failure(Error.Validation(...))` for handlers returning `Result<T>`; throws `ValidationException` (caught by new global middleware → HTTP 400) for other response types.

- **Bug 3 (DbUpdateConcurrencyException on composition update)**: When loading a `Flock` without its `History` collection and then calling `UpdateComposition`, EF Core's observable navigation collection fires `CollectionChanged` events. New `FlockHistory` entries with non-default GUID keys are incorrectly marked `Modified` instead of `Added`. `UpdateAsync` now corrects the entity state before `SaveChanges`, ensuring INSERT is generated.

## Test Plan

- [x] All 571 backend tests pass (Application: 341, Infrastructure: 122, Api: 107 — including new `ValidationBehaviorTests` and `FlockRepositoryTests`)
- [x] All 777 frontend unit tests pass
- [x] Frontend lint passes (0 errors, 1 pre-existing warning unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)