### PR TITLE
fix: replace stringly-typed error switch blocks with ToHttpResult() extension

### DIFF
--- a/backend/src/Chickquita.Api/Endpoints/CoopsEndpoints.cs
+++ b/backend/src/Chickquita.Api/Endpoints/CoopsEndpoints.cs
@@ -1,3 +1,4 @@
+using Chickquita.Api.Extensions;
 using Chickquita.Application.DTOs;
 using Chickquita.Application.Features.Coops.Commands;
 using Chickquita.Application.Features.Coops.Queries;
@@ -68,16 +69,7 @@ public static class CoopsEndpoints
         var query = new GetCoopsQuery { IncludeArchived = includeArchived };
         var result = await mediator.Send(query);
 
-        if (!result.IsSuccess)
-        {
-            return result.Error.Code switch
-            {
-                "Error.Unauthorized" => Results.Unauthorized(),
-                _ => Results.BadRequest(new { error = result.Error })
-            };
-        }
-
-        return Results.Ok(result.Value);
+        return result.ToHttpResult();
     }
 
     private static async Task<IResult> GetCoopById(
@@ -87,17 +79,7 @@ public static class CoopsEndpoints
         var query = new GetCoopByIdQuery { Id = id };
         var result = await mediator.Send(query);
 
-        if (!result.IsSuccess)
-        {
-            return result.Error.Code switch
-            {
-                "Error.Unauthorized" => Results.Unauthorized(),
-                "Error.NotFound" => Results.NotFound(new { error = result.Error }),
-                _ => Results.BadRequest(new { error = result.Error })
-            };
-        }
-
-        return Results.Ok(result.Value);
+        return result.ToHttpResult();
     }
 
     private static async Task<IResult> CreateCoop(
@@ -106,18 +88,7 @@ public static class CoopsEndpoints
     {
         var result = await mediator.Send(command);
 
-        if (!result.IsSuccess)
-        {
-            return result.Error.Code switch
-            {
-                "Error.Unauthorized" => Results.Unauthorized(),
-                "Error.Validation" => Results.BadRequest(new { error = result.Error }),
-                "Error.Conflict" => Results.Conflict(new { error = result.Error }),
-                _ => Results.BadRequest(new { error = result.Error })
-            };
-        }
-
-        return Results.Created($"/api/coops/{result.Value.Id}", result.Value);
+        return result.ToHttpResult(value => Results.Created($"/api/coops/{value.Id}", value));
     }
 
     private static async Task<IResult> UpdateCoop(
@@ -133,19 +104,7 @@ public static class CoopsEndpoints
 
         var result = await mediator.Send(command);
 
-        if (!result.IsSuccess)
-        {
-            return result.Error.Code switch
-            {
-                "Error.Unauthorized" => Results.Unauthorized(),
-                "Error.Validation" => Results.BadRequest(new { error = result.Error }),
-                "Error.NotFound" => Results.NotFound(new { error = result.Error }),
-                "Error.Conflict" => Results.Conflict(new { error = result.Error }),
-                _ => Results.BadRequest(new { error = result.Error })
-            };
-        }
-
-        return Results.Ok(result.Value);
+        return result.ToHttpResult();
     }
 
     private static async Task<IResult> DeleteCoop(
@@ -155,18 +114,7 @@ public static class CoopsEndpoints
         var command = new DeleteCoopCommand { Id = id };
         var result = await mediator.Send(command);
 
-        if (!result.IsSuccess)
-        {
-            return result.Error.Code switch
-            {
-                "Error.Unauthorized" => Results.Unauthorized(),
-                "Error.Validation" => Results.BadRequest(new { error = result.Error }),
-                "Error.NotFound" => Results.NotFound(new { error = result.Error }),
-                _ => Results.BadRequest(new { error = result.Error })
-            };
-        }
-
-        return Results.Ok(result.Value);
+        return result.ToHttpResult();
     }
 
     private static async Task<IResult> ArchiveCoop(
@@ -176,17 +124,6 @@ public static class CoopsEndpoints
         var command = new ArchiveCoopCommand { Id = id };
         var result = await mediator.Send(command);
 
-        if (!result.IsSuccess)
-        {
-            return result.Error.Code switch
-            {
-                "Error.Unauthorized" => Results.Unauthorized(),
-                "Error.Validation" => Results.BadRequest(new { error = result.Error }),
-                "Error.NotFound" => Results.NotFound(new { error = result.Error }),
-                _ => Results.BadRequest(new { error = result.Error })
-            };
-        }
-
-        return Results.Ok(result.Value);
+        return result.ToHttpResult();
     }
 }

--- a/backend/src/Chickquita.Api/Endpoints/DailyRecordsEndpoints.cs
+++ b/backend/src/Chickquita.Api/Endpoints/DailyRecordsEndpoints.cs
@@ -1,3 +1,4 @@
+using Chickquita.Api.Extensions;
 using Chickquita.Application.DTOs;
 using Chickquita.Application.Features.DailyRecords.Commands;
 using Chickquita.Application.Features.DailyRecords.Queries;
@@ -76,17 +77,7 @@ public static class DailyRecordsEndpoints
         };
         var result = await mediator.Send(query);
 
-        if (!result.IsSuccess)
-        {
-            return result.Error.Code switch
-            {
-                "Error.Unauthorized" => Results.Unauthorized(),
-                "Error.NotFound" => Results.NotFound(new { error = result.Error }),
-                _ => Results.BadRequest(new { error = result.Error })
-            };
-        }
-
-        return Results.Ok(result.Value);
+        return result.ToHttpResult();
     }
 
     private static async Task<IResult> GetDailyRecordsByFlock(
@@ -103,17 +94,7 @@ public static class DailyRecordsEndpoints
         };
         var result = await mediator.Send(query);
 
-        if (!result.IsSuccess)
-        {
-            return result.Error.Code switch
-            {
-                "Error.Unauthorized" => Results.Unauthorized(),
-                "Error.NotFound" => Results.NotFound(new { error = result.Error }),
-                _ => Results.BadRequest(new { error = result.Error })
-            };
-        }
-
-        return Results.Ok(result.Value);
+        return result.ToHttpResult();
     }
 
     private static async Task<IResult> CreateDailyRecord(
@@ -126,18 +107,7 @@ public static class DailyRecordsEndpoints
 
         var result = await mediator.Send(command);
 
-        if (!result.IsSuccess)
-        {
-            return result.Error.Code switch
-            {
-                "Error.Unauthorized" => Results.Unauthorized(),
-                "Error.Validation" => Results.BadRequest(new { error = result.Error }),
-                "Error.NotFound" => Results.NotFound(new { error = result.Error }),
-                _ => Results.BadRequest(new { error = result.Error })
-            };
-        }
-
-        return Results.Created($"/api/daily-records/{result.Value.Id}", result.Value);
+        return result.ToHttpResult(value => Results.Created($"/api/daily-records/{value.Id}", value));
     }
 
     private static async Task<IResult> UpdateDailyRecord(
@@ -153,18 +123,7 @@ public static class DailyRecordsEndpoints
 
         var result = await mediator.Send(command);
 
-        if (!result.IsSuccess)
-        {
-            return result.Error.Code switch
-            {
-                "Error.Unauthorized" => Results.Unauthorized(),
-                "Error.Validation" => Results.BadRequest(new { error = result.Error }),
-                "Error.NotFound" => Results.NotFound(new { error = result.Error }),
-                _ => Results.BadRequest(new { error = result.Error })
-            };
-        }
-
-        return Results.Ok(result.Value);
+        return result.ToHttpResult();
     }
 
     private static async Task<IResult> DeleteDailyRecord(
@@ -174,16 +133,6 @@ public static class DailyRecordsEndpoints
         var command = new DeleteDailyRecordCommand { Id = id };
         var result = await mediator.Send(command);
 
-        if (!result.IsSuccess)
-        {
-            return result.Error.Code switch
-            {
-                "Error.Unauthorized" => Results.Unauthorized(),
-                "Error.NotFound" => Results.NotFound(new { error = result.Error }),
-                _ => Results.BadRequest(new { error = result.Error })
-            };
-        }
-
-        return Results.NoContent();
+        return result.ToHttpResult(_ => Results.NoContent());
     }
 }

--- a/backend/src/Chickquita.Api/Endpoints/FlockHistoryEndpoints.cs
+++ b/backend/src/Chickquita.Api/Endpoints/FlockHistoryEndpoints.cs
@@ -1,3 +1,4 @@
+using Chickquita.Api.Extensions;
 using Chickquita.Application.DTOs;
 using Chickquita.Application.Features.FlockHistory.Commands;
 using Chickquita.Application.Features.Flocks.Queries;
@@ -43,17 +44,7 @@ public static class FlockHistoryEndpoints
         var query = new GetFlockHistoryQuery { FlockId = id };
         var result = await mediator.Send(query);
 
-        if (!result.IsSuccess)
-        {
-            return result.Error.Code switch
-            {
-                "Error.Unauthorized" => Results.Unauthorized(),
-                "Error.NotFound" or "Flock.NotFound" => Results.NotFound(new { error = result.Error }),
-                _ => Results.BadRequest(new { error = result.Error })
-            };
-        }
-
-        return Results.Ok(result.Value);
+        return result.ToHttpResult();
     }
 
     private static async Task<IResult> UpdateFlockHistoryNotes(
@@ -69,18 +60,7 @@ public static class FlockHistoryEndpoints
 
         var result = await mediator.Send(command);
 
-        if (!result.IsSuccess)
-        {
-            return result.Error.Code switch
-            {
-                "Error.Unauthorized" => Results.Unauthorized(),
-                "Error.NotFound" or "FlockHistory.NotFound" => Results.NotFound(new { error = result.Error }),
-                "Error.Validation" or "FlockHistory.ValidationError" => Results.BadRequest(new { error = result.Error }),
-                _ => Results.BadRequest(new { error = result.Error })
-            };
-        }
-
-        return Results.Ok(result.Value);
+        return result.ToHttpResult();
     }
 }
 

--- a/backend/src/Chickquita.Api/Endpoints/FlocksEndpoints.cs
+++ b/backend/src/Chickquita.Api/Endpoints/FlocksEndpoints.cs
@@ -1,3 +1,4 @@
+using Chickquita.Api.Extensions;
 using Chickquita.Application.DTOs;
 using Chickquita.Application.Features.Flocks.Commands;
 using Chickquita.Application.Features.Flocks.Queries;
@@ -92,17 +93,7 @@ public static class FlocksEndpoints
         };
         var result = await mediator.Send(query);
 
-        if (!result.IsSuccess)
-        {
-            return result.Error.Code switch
-            {
-                "Error.Unauthorized" => Results.Unauthorized(),
-                "Error.NotFound" => Results.NotFound(new { error = result.Error }),
-                _ => Results.BadRequest(new { error = result.Error })
-            };
-        }
-
-        return Results.Ok(result.Value);
+        return result.ToHttpResult();
     }
 
     private static async Task<IResult> GetFlocksByCoop(
@@ -140,17 +131,7 @@ public static class FlocksEndpoints
         };
         var result = await mediator.Send(query);
 
-        if (!result.IsSuccess)
-        {
-            return result.Error.Code switch
-            {
-                "Error.Unauthorized" => Results.Unauthorized(),
-                "Error.NotFound" => Results.NotFound(new { error = result.Error }),
-                _ => Results.BadRequest(new { error = result.Error })
-            };
-        }
-
-        return Results.Ok(result.Value);
+        return result.ToHttpResult();
     }
 
     private static async Task<IResult> CreateFlock(
@@ -163,18 +144,7 @@ public static class FlocksEndpoints
 
         var result = await mediator.Send(command);
 
-        if (!result.IsSuccess)
-        {
-            return result.Error.Code switch
-            {
-                "Error.Unauthorized" => Results.Unauthorized(),
-                "Error.Validation" => Results.BadRequest(new { error = result.Error }),
-                "Error.NotFound" => Results.NotFound(new { error = result.Error }),
-                _ => Results.BadRequest(new { error = result.Error })
-            };
-        }
-
-        return Results.Created($"/api/flocks/{result.Value.Id}", result.Value);
+        return result.ToHttpResult(value => Results.Created($"/api/flocks/{value.Id}", value));
     }
 
     private static async Task<IResult> UpdateFlock(
@@ -190,18 +160,7 @@ public static class FlocksEndpoints
 
         var result = await mediator.Send(command);
 
-        if (!result.IsSuccess)
-        {
-            return result.Error.Code switch
-            {
-                "Error.Unauthorized" => Results.Unauthorized(),
-                "Error.Validation" => Results.BadRequest(new { error = result.Error }),
-                "Error.NotFound" => Results.NotFound(new { error = result.Error }),
-                _ => Results.BadRequest(new { error = result.Error })
-            };
-        }
-
-        return Results.Ok(result.Value);
+        return result.ToHttpResult();
     }
 
     private static async Task<IResult> ArchiveFlock(
@@ -211,18 +170,7 @@ public static class FlocksEndpoints
         var command = new ArchiveFlockCommand { FlockId = id };
         var result = await mediator.Send(command);
 
-        if (!result.IsSuccess)
-        {
-            return result.Error.Code switch
-            {
-                "Error.Unauthorized" => Results.Unauthorized(),
-                "Error.Validation" => Results.BadRequest(new { error = result.Error }),
-                "Error.NotFound" => Results.NotFound(new { error = result.Error }),
-                _ => Results.BadRequest(new { error = result.Error })
-            };
-        }
-
-        return Results.Ok(result.Value);
+        return result.ToHttpResult();
     }
 
     private static async Task<IResult> MatureChicks(
@@ -233,17 +181,6 @@ public static class FlocksEndpoints
         command.FlockId = id;
         var result = await mediator.Send(command);
 
-        if (!result.IsSuccess)
-        {
-            return result.Error.Code switch
-            {
-                "Error.Unauthorized" => Results.Unauthorized(),
-                "Error.Validation" => Results.BadRequest(new { error = result.Error }),
-                "Error.NotFound" => Results.NotFound(new { error = result.Error }),
-                _ => Results.BadRequest(new { error = result.Error })
-            };
-        }
-
-        return Results.Ok(result.Value);
+        return result.ToHttpResult();
     }
 }

--- a/backend/src/Chickquita.Api/Endpoints/PurchasesEndpoints.cs
+++ b/backend/src/Chickquita.Api/Endpoints/PurchasesEndpoints.cs
@@ -1,3 +1,4 @@
+using Chickquita.Api.Extensions;
 using Chickquita.Application.DTOs;
 using Chickquita.Application.Features.Purchases.Commands.Create;
 using Chickquita.Application.Features.Purchases.Commands.Update;
@@ -112,17 +113,7 @@ public static class PurchasesEndpoints
 
         var result = await mediator.Send(query);
 
-        if (!result.IsSuccess)
-        {
-            return result.Error.Code switch
-            {
-                "Error.Unauthorized" => Results.Unauthorized(),
-                "Error.NotFound" => Results.NotFound(new { error = result.Error }),
-                _ => Results.BadRequest(new { error = result.Error })
-            };
-        }
-
-        return Results.Ok(result.Value);
+        return result.ToHttpResult();
     }
 
     private static async Task<IResult> GetPurchaseById(
@@ -132,17 +123,7 @@ public static class PurchasesEndpoints
         var query = new GetPurchaseByIdQuery { Id = id };
         var result = await mediator.Send(query);
 
-        if (!result.IsSuccess)
-        {
-            return result.Error.Code switch
-            {
-                "Error.Unauthorized" => Results.Unauthorized(),
-                "Error.NotFound" => Results.NotFound(new { error = result.Error }),
-                _ => Results.BadRequest(new { error = result.Error })
-            };
-        }
-
-        return Results.Ok(result.Value);
+        return result.ToHttpResult();
     }
 
     private static async Task<IResult> GetPurchaseNames(
@@ -158,16 +139,7 @@ public static class PurchasesEndpoints
 
         var result = await mediator.Send(purchaseNamesQuery);
 
-        if (!result.IsSuccess)
-        {
-            return result.Error.Code switch
-            {
-                "Error.Unauthorized" => Results.Unauthorized(),
-                _ => Results.BadRequest(new { error = result.Error })
-            };
-        }
-
-        return Results.Ok(result.Value);
+        return result.ToHttpResult();
     }
 
     private static async Task<IResult> CreatePurchase(
@@ -176,18 +148,7 @@ public static class PurchasesEndpoints
     {
         var result = await mediator.Send(command);
 
-        if (!result.IsSuccess)
-        {
-            return result.Error.Code switch
-            {
-                "Error.Unauthorized" => Results.Unauthorized(),
-                "Error.Validation" => Results.BadRequest(new { error = result.Error }),
-                "Error.NotFound" => Results.NotFound(new { error = result.Error }),
-                _ => Results.BadRequest(new { error = result.Error })
-            };
-        }
-
-        return Results.Created($"/api/purchases/{result.Value.Id}", result.Value);
+        return result.ToHttpResult(value => Results.Created($"/api/purchases/{value.Id}", value));
     }
 
     private static async Task<IResult> UpdatePurchase(
@@ -203,19 +164,7 @@ public static class PurchasesEndpoints
 
         var result = await mediator.Send(command);
 
-        if (!result.IsSuccess)
-        {
-            return result.Error.Code switch
-            {
-                "Error.Unauthorized" => Results.Unauthorized(),
-                "Error.Validation" => Results.BadRequest(new { error = result.Error }),
-                "Error.NotFound" => Results.NotFound(new { error = result.Error }),
-                "Error.Forbidden" => Results.Forbid(),
-                _ => Results.BadRequest(new { error = result.Error })
-            };
-        }
-
-        return Results.Ok(result.Value);
+        return result.ToHttpResult();
     }
 
     private static async Task<IResult> DeletePurchase(
@@ -225,18 +174,6 @@ public static class PurchasesEndpoints
         var command = new DeletePurchaseCommand { PurchaseId = id };
         var result = await mediator.Send(command);
 
-        if (!result.IsSuccess)
-        {
-            return result.Error.Code switch
-            {
-                "Error.Unauthorized" => Results.Unauthorized(),
-                "Error.Validation" => Results.BadRequest(new { error = result.Error }),
-                "Error.NotFound" => Results.NotFound(new { error = result.Error }),
-                "Error.Forbidden" => Results.Forbid(),
-                _ => Results.BadRequest(new { error = result.Error })
-            };
-        }
-
-        return Results.NoContent();
+        return result.ToHttpResult(_ => Results.NoContent());
     }
 }

--- a/backend/src/Chickquita.Api/Endpoints/StatisticsEndpoints.cs
+++ b/backend/src/Chickquita.Api/Endpoints/StatisticsEndpoints.cs
@@ -1,3 +1,4 @@
+using Chickquita.Api.Extensions;
 using Chickquita.Application.DTOs;
 using Chickquita.Application.Features.Statistics.Queries;
 using MediatR;
@@ -47,16 +48,7 @@ public static class StatisticsEndpoints
         var query = new GetDashboardStatsQuery();
         var result = await mediator.Send(query);
 
-        if (!result.IsSuccess)
-        {
-            return result.Error.Code switch
-            {
-                "Error.Unauthorized" => Results.Unauthorized(),
-                _ => Results.BadRequest(new { error = result.Error })
-            };
-        }
-
-        return Results.Ok(result.Value);
+        return result.ToHttpResult();
     }
 
     /// <summary>
@@ -127,15 +119,6 @@ public static class StatisticsEndpoints
 
         var result = await mediator.Send(query);
 
-        if (!result.IsSuccess)
-        {
-            return result.Error.Code switch
-            {
-                "Error.Unauthorized" => Results.Unauthorized(),
-                _ => Results.BadRequest(new { error = result.Error })
-            };
-        }
-
-        return Results.Ok(result.Value);
+        return result.ToHttpResult();
     }
 }

--- a/backend/src/Chickquita.Api/Endpoints/UsersEndpoints.cs
+++ b/backend/src/Chickquita.Api/Endpoints/UsersEndpoints.cs
@@ -1,3 +1,4 @@
+using Chickquita.Api.Extensions;
 using Chickquita.Application.DTOs;
 using Chickquita.Application.Features.Users.Queries;
 using MediatR;
@@ -27,16 +28,6 @@ public static class UsersEndpoints
         var query = new GetCurrentUserQuery();
         var result = await mediator.Send(query);
 
-        if (!result.IsSuccess)
-        {
-            return result.Error.Code switch
-            {
-                "Error.Unauthorized" => Results.Unauthorized(),
-                "Error.NotFound" => Results.NotFound(new { error = result.Error }),
-                _ => Results.BadRequest(new { error = result.Error })
-            };
-        }
-
-        return Results.Ok(result.Value);
+        return result.ToHttpResult();
     }
 }

--- a/backend/src/Chickquita.Api/Extensions/ResultExtensions.cs
+++ b/backend/src/Chickquita.Api/Extensions/ResultExtensions.cs
@@ -1,0 +1,29 @@
+using Chickquita.Domain.Common;
+
+namespace Chickquita.Api.Extensions;
+
+/// <summary>
+/// Extension methods for mapping Result&lt;T&gt; to IResult HTTP responses.
+/// </summary>
+public static class ResultExtensions
+{
+    /// <summary>
+    /// Converts a Result&lt;T&gt; to an IResult HTTP response.
+    /// On success, calls <paramref name="onSuccess"/> if provided, otherwise returns 200 OK with the value.
+    /// On failure, maps the error code to the appropriate HTTP status code.
+    /// </summary>
+    public static IResult ToHttpResult<T>(this Result<T> result, Func<T, IResult>? onSuccess = null)
+    {
+        if (result.IsSuccess)
+            return onSuccess is not null ? onSuccess(result.Value) : Results.Ok(result.Value);
+
+        return result.Error.Code switch
+        {
+            "Error.Unauthorized" => Results.Unauthorized(),
+            "Error.NotFound"     => Results.NotFound(new { error = result.Error }),
+            "Error.Forbidden"    => Results.Forbid(),
+            "Error.Conflict"     => Results.Conflict(new { error = result.Error }),
+            _                    => Results.BadRequest(new { error = result.Error })
+        };
+    }
+}

--- a/backend/tests/Chickquita.Api.Tests/Extensions/ResultExtensionsTests.cs
+++ b/backend/tests/Chickquita.Api.Tests/Extensions/ResultExtensionsTests.cs
@@ -1,0 +1,188 @@
+using Chickquita.Api.Extensions;
+using Chickquita.Domain.Common;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace Chickquita.Api.Tests.Extensions;
+
+/// <summary>
+/// Unit tests for ResultExtensions.ToHttpResult().
+/// Verifies that each error code maps to the correct HTTP status code.
+/// </summary>
+public class ResultExtensionsTests
+{
+    // ── Success ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ToHttpResult_Success_Returns200WithValue()
+    {
+        var result = Result<string>.Success("hello");
+
+        var httpResult = result.ToHttpResult();
+
+        var statusResult = httpResult as IStatusCodeHttpResult;
+        statusResult.Should().NotBeNull();
+        statusResult!.StatusCode.Should().Be(StatusCodes.Status200OK);
+    }
+
+    [Fact]
+    public void ToHttpResult_Success_ValueIsPreserved()
+    {
+        var result = Result<string>.Success("hello");
+
+        var httpResult = result.ToHttpResult();
+
+        httpResult.Should().BeOfType<Ok<string>>()
+            .Which.Value.Should().Be("hello");
+    }
+
+    [Fact]
+    public void ToHttpResult_SuccessWithOnSuccessCallback_CallsCallback()
+    {
+        var result = Result<string>.Success("hello");
+        var callbackCalled = false;
+
+        var httpResult = result.ToHttpResult(value =>
+        {
+            callbackCalled = true;
+            return Results.Created("/api/items/1", value);
+        });
+
+        callbackCalled.Should().BeTrue();
+        var statusResult = httpResult as IStatusCodeHttpResult;
+        statusResult!.StatusCode.Should().Be(StatusCodes.Status201Created);
+    }
+
+    [Fact]
+    public void ToHttpResult_SuccessWithNullOnSuccessCallback_Returns200()
+    {
+        var result = Result<int>.Success(42);
+
+        var httpResult = result.ToHttpResult(onSuccess: null);
+
+        var statusResult = httpResult as IStatusCodeHttpResult;
+        statusResult!.StatusCode.Should().Be(StatusCodes.Status200OK);
+    }
+
+    // ── Error.Unauthorized ────────────────────────────────────────────────────
+
+    [Fact]
+    public void ToHttpResult_UnauthorizedError_Returns401()
+    {
+        var result = Result<string>.Failure(Error.Unauthorized("Not authenticated"));
+
+        var httpResult = result.ToHttpResult();
+
+        var statusResult = httpResult as IStatusCodeHttpResult;
+        statusResult.Should().NotBeNull();
+        statusResult!.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+    }
+
+    // ── Error.NotFound ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ToHttpResult_NotFoundError_Returns404()
+    {
+        var result = Result<string>.Failure(Error.NotFound("Item not found"));
+
+        var httpResult = result.ToHttpResult();
+
+        var statusResult = httpResult as IStatusCodeHttpResult;
+        statusResult.Should().NotBeNull();
+        statusResult!.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    // ── Error.Forbidden ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void ToHttpResult_ForbiddenError_ReturnsForbidResult()
+    {
+        var result = Result<string>.Failure(Error.Forbidden("Access denied"));
+
+        var httpResult = result.ToHttpResult();
+
+        httpResult.Should().BeOfType<ForbidHttpResult>();
+    }
+
+    // ── Error.Conflict ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ToHttpResult_ConflictError_Returns409()
+    {
+        var result = Result<string>.Failure(Error.Conflict("Resource already exists"));
+
+        var httpResult = result.ToHttpResult();
+
+        var statusResult = httpResult as IStatusCodeHttpResult;
+        statusResult.Should().NotBeNull();
+        statusResult!.StatusCode.Should().Be(StatusCodes.Status409Conflict);
+    }
+
+    // ── Error.Failure / unknown codes → BadRequest ────────────────────────────
+
+    [Fact]
+    public void ToHttpResult_FailureError_Returns400()
+    {
+        var result = Result<string>.Failure(Error.Failure("Something went wrong"));
+
+        var httpResult = result.ToHttpResult();
+
+        var statusResult = httpResult as IStatusCodeHttpResult;
+        statusResult.Should().NotBeNull();
+        statusResult!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Fact]
+    public void ToHttpResult_ValidationError_Returns400()
+    {
+        var result = Result<string>.Failure(Error.Validation("Name is required"));
+
+        var httpResult = result.ToHttpResult();
+
+        var statusResult = httpResult as IStatusCodeHttpResult;
+        statusResult!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Fact]
+    public void ToHttpResult_ValidationWithSubcode_Returns400()
+    {
+        var result = Result<string>.Failure(Error.ValidationWithCode("Name", "Name is required"));
+
+        var httpResult = result.ToHttpResult();
+
+        var statusResult = httpResult as IStatusCodeHttpResult;
+        statusResult!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Fact]
+    public void ToHttpResult_UnknownErrorCode_Returns400()
+    {
+        var error = new Error("Some.CustomCode", "Unexpected error");
+        var result = Result<string>.Failure(error);
+
+        var httpResult = result.ToHttpResult();
+
+        var statusResult = httpResult as IStatusCodeHttpResult;
+        statusResult!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    // ── onSuccess callback is NOT called on failure ───────────────────────────
+
+    [Fact]
+    public void ToHttpResult_FailureWithOnSuccessCallback_CallbackNotInvoked()
+    {
+        var result = Result<string>.Failure(Error.NotFound("Not found"));
+        var callbackCalled = false;
+
+        var httpResult = result.ToHttpResult(value =>
+        {
+            callbackCalled = true;
+            return Results.Created("/api/items/1", value);
+        });
+
+        callbackCalled.Should().BeFalse();
+        var statusResult = httpResult as IStatusCodeHttpResult;
+        statusResult!.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+    }
+}


### PR DESCRIPTION
## Summary

- Introduces `ResultExtensions.ToHttpResult<T>()` in `Chickquita.Api.Extensions` — a single extension method that centralises the `Result<T>` → `IResult` HTTP mapping
- Removes ~30 duplicate `result.Error.Code switch { ... }` blocks spread across 7 endpoint files
- Dead-code non-standard error codes (`Flock.NotFound`, `FlockHistory.NotFound`, `FlockHistory.ValidationError`) in `FlockHistoryEndpoints` were silently dropped — these codes are never produced by the underlying handlers

## Changes

- `backend/src/Chickquita.Api/Extensions/ResultExtensions.cs` — new file, DRY mapping logic
- `backend/src/Chickquita.Api/Endpoints/CoopsEndpoints.cs` — refactored
- `backend/src/Chickquita.Api/Endpoints/FlocksEndpoints.cs` — refactored
- `backend/src/Chickquita.Api/Endpoints/DailyRecordsEndpoints.cs` — refactored
- `backend/src/Chickquita.Api/Endpoints/PurchasesEndpoints.cs` — refactored
- `backend/src/Chickquita.Api/Endpoints/FlockHistoryEndpoints.cs` — refactored
- `backend/src/Chickquita.Api/Endpoints/StatisticsEndpoints.cs` — refactored
- `backend/src/Chickquita.Api/Endpoints/UsersEndpoints.cs` — refactored

## Tests

- `backend/tests/Chickquita.Api.Tests/Extensions/ResultExtensionsTests.cs` — 12 unit tests covering every mapped error code (Unauthorized → 401, NotFound → 404, Forbidden → ForbidHttpResult, Conflict → 409, all others → 400), success with and without `onSuccess` callback, and verification that the callback is not invoked on failure

Closes #81