### PR TITLE
fix: throw at startup if Clerk:Authority config is missing (#89)

### DIFF
--- a/backend/src/Chickquita.Infrastructure/DependencyInjection.cs
+++ b/backend/src/Chickquita.Infrastructure/DependencyInjection.cs
@@ -67,32 +67,33 @@ public static class DependencyInjection
         // Register tenant service
         services.AddScoped<ITenantService, TenantService>();
 
-        // Configure JWT Bearer Authentication
-        var clerkAuthority = configuration["Clerk:Authority"];
+        // Configure JWT Bearer Authentication — fail fast if required config is absent
+        var clerkAuthority = configuration["Clerk:Authority"]
+            ?? throw new InvalidOperationException(
+                "Clerk:Authority is required but not configured. " +
+                "Set the Clerk__Authority environment variable.");
+
         var clerkAudience = configuration["Clerk:Audience"];
 
-        if (!string.IsNullOrEmpty(clerkAuthority))
-        {
-            services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
-                .AddJwtBearer(options =>
+        services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+            .AddJwtBearer(options =>
+            {
+                options.Authority = clerkAuthority;
+                options.TokenValidationParameters = new TokenValidationParameters
                 {
-                    options.Authority = clerkAuthority;
-                    options.TokenValidationParameters = new TokenValidationParameters
-                    {
-                        ValidateIssuer = true,
-                        ValidateAudience = !string.IsNullOrEmpty(clerkAudience),
-                        ValidAudience = clerkAudience,
-                        ValidateLifetime = true,
-                        ValidateIssuerSigningKey = true,
-                        ClockSkew = TimeSpan.FromMinutes(5)
-                    };
+                    ValidateIssuer = true,
+                    ValidateAudience = !string.IsNullOrEmpty(clerkAudience),
+                    ValidAudience = clerkAudience,
+                    ValidateLifetime = true,
+                    ValidateIssuerSigningKey = true,
+                    ClockSkew = TimeSpan.FromMinutes(5)
+                };
 
-                    // Map the Clerk "sub" claim to ClaimTypes.NameIdentifier
-                    options.MapInboundClaims = false;
-                });
+                // Map the Clerk "sub" claim to ClaimTypes.NameIdentifier
+                options.MapInboundClaims = false;
+            });
 
-            services.AddAuthorization();
-        }
+        services.AddAuthorization();
 
         return services;
     }

--- a/backend/tests/Chickquita.Infrastructure.Tests/DependencyInjectionTests.cs
+++ b/backend/tests/Chickquita.Infrastructure.Tests/DependencyInjectionTests.cs
@@ -1,0 +1,55 @@
+using Chickquita.Infrastructure;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Chickquita.Infrastructure.Tests;
+
+/// <summary>
+/// Tests that AddInfrastructureServices fails fast when required configuration is absent.
+/// </summary>
+public class DependencyInjectionTests
+{
+    [Fact]
+    public void AddInfrastructureServices_WhenClerkAuthorityMissing_ThrowsInvalidOperationException()
+    {
+        // Arrange — config without Clerk:Authority
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = "Host=localhost;Database=test",
+                ["ASPNETCORE_ENVIRONMENT"] = "Development"
+                // Clerk:Authority intentionally omitted
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+
+        // Act
+        var act = () => services.AddInfrastructureServices(config);
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Clerk:Authority*");
+    }
+
+    [Fact]
+    public void AddInfrastructureServices_WhenClerkAuthorityPresent_DoesNotThrow()
+    {
+        // Arrange — config with Clerk:Authority set
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = "Host=localhost;Database=test",
+                ["ASPNETCORE_ENVIRONMENT"] = "Development",
+                ["Clerk:Authority"] = "https://example.clerk.accounts.dev"
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+
+        // Act & Assert
+        var act = () => services.AddInfrastructureServices(config);
+        act.Should().NotThrow();
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #89 — if `Clerk:Authority` was absent from config, JWT authentication was silently not registered, leaving all protected endpoints publicly accessible.

## Changes

`DependencyInjection.cs` — replaced the conditional `if (!string.IsNullOrEmpty(authority))` guard with a null-coalescing throw. Authentication is now always registered; missing config throws at startup instead of allowing an unauthenticated app to run.

## Tests

Added `DependencyInjectionTests` to `Chickquita.Infrastructure.Tests`:
- `AddInfrastructureServices_WhenClerkAuthorityMissing_ThrowsInvalidOperationException`
- `AddInfrastructureServices_WhenClerkAuthorityPresent_DoesNotThrow`