### PR TITLE
fix: catch WebhookVerificationException by type reference, not string name

### DIFF
--- a/backend/src/Chickquita.Infrastructure/Services/ClerkWebhookValidator.cs
+++ b/backend/src/Chickquita.Infrastructure/Services/ClerkWebhookValidator.cs
@@ -5,6 +5,7 @@ using Chickquita.Application.Interfaces;
 using Chickquita.Domain.Common;
 using Microsoft.Extensions.Configuration;
 using Svix;
+using Svix.Exceptions;
 
 namespace Chickquita.Infrastructure.Services;
 
@@ -67,7 +68,7 @@ public sealed class ClerkWebhookValidator : IClerkWebhookValidator
 
             return Result<ClerkWebhookDto>.Success(webhookDto);
         }
-        catch (Exception ex) when (ex.GetType().Name == "WebhookVerificationException")
+        catch (WebhookVerificationException ex)
         {
             // Signature validation failed - webhook is not authentic
             return Result<ClerkWebhookDto>.Failure(


### PR DESCRIPTION
Closes #91

## Problem

The `catch` clause in `ClerkWebhookValidator.ValidateWebhook` was matching the Svix `WebhookVerificationException` by comparing the exception type name as a string:

```csharp
catch (Exception ex) when (ex.GetType().Name == "WebhookVerificationException")
```

This is fragile — it silently breaks if the Svix package renames the exception class, the class is in a subclassed hierarchy, or a refactor touches the type name. The `when` filter also means the exception still propagates up the stack if the condition is false, leaking internal details.

## Fix

Replace with a direct typed `catch`:

```csharp
using Svix.Exceptions;
// ...
catch (WebhookVerificationException ex)
```

The compiler now validates the type at build time. If the Svix package changes the exception class, the build fails with a clear error rather than silently missing the catch at runtime.

## Tests

No new tests required — the existing `ValidateWebhook_WithTamperedPayload_ReturnsFailure` and `ValidateWebhook_WithInvalidSignature_ReturnsFailure` tests in `ClerkWebhookValidatorTests` already exercise this exact catch block using real Svix calls that throw `WebhookVerificationException`.