### PR TITLE
fix: replace full entity fetches used only for existence checks with ExistsAsync

### DIFF
--- a/backend/src/Chickquita.Application/Features/DailyRecords/Queries/GetDailyRecordsQueryHandler.cs
+++ b/backend/src/Chickquita.Application/Features/DailyRecords/Queries/GetDailyRecordsQueryHandler.cs
@@ -66,8 +66,7 @@ public sealed class GetDailyRecordsQueryHandler : IRequestHandler<GetDailyRecord
             if (request.FlockId.HasValue && request.StartDate.HasValue && request.EndDate.HasValue)
             {
                 // Verify the flock exists and belongs to the current tenant
-                var flock = await _flockRepository.GetByIdAsync(request.FlockId.Value);
-                if (flock == null)
+                if (!await _flockRepository.ExistsAsync(request.FlockId.Value))
                 {
                     _logger.LogWarning(
                         "GetDailyRecordsQuery: Flock not found with ID: {FlockId}",
@@ -84,8 +83,7 @@ public sealed class GetDailyRecordsQueryHandler : IRequestHandler<GetDailyRecord
             else if (request.FlockId.HasValue)
             {
                 // Verify the flock exists and belongs to the current tenant
-                var flock = await _flockRepository.GetByIdAsync(request.FlockId.Value);
-                if (flock == null)
+                if (!await _flockRepository.ExistsAsync(request.FlockId.Value))
                 {
                     _logger.LogWarning(
                         "GetDailyRecordsQuery: Flock not found with ID: {FlockId}",

--- a/backend/src/Chickquita.Application/Features/Flocks/Commands/CreateFlockCommandHandler.cs
+++ b/backend/src/Chickquita.Application/Features/Flocks/Commands/CreateFlockCommandHandler.cs
@@ -60,8 +60,7 @@ public sealed class CreateFlockCommandHandler : IRequestHandler<CreateFlockComma
             var tenantId = _currentUserService.TenantId;
 
             // Check if the coop exists and belongs to the current tenant
-            var coop = await _coopRepository.GetByIdAsync(request.CoopId);
-            if (coop == null)
+            if (!await _coopRepository.ExistsAsync(request.CoopId))
             {
                 _logger.LogWarning(
                     "CreateFlockCommand: Coop with ID {CoopId} not found for tenant {TenantId}",

--- a/backend/src/Chickquita.Application/Features/Flocks/Queries/GetFlocksQueryHandler.cs
+++ b/backend/src/Chickquita.Application/Features/Flocks/Queries/GetFlocksQueryHandler.cs
@@ -65,8 +65,7 @@ public sealed class GetFlocksQueryHandler : IRequestHandler<GetFlocksQuery, Resu
             if (request.CoopId.HasValue)
             {
                 // Verify the coop exists and belongs to the current tenant
-                var coop = await _coopRepository.GetByIdAsync(request.CoopId.Value);
-                if (coop == null)
+                if (!await _coopRepository.ExistsAsync(request.CoopId.Value))
                 {
                     _logger.LogWarning(
                         "GetFlocksQuery: Coop not found with ID: {CoopId}",

--- a/backend/src/Chickquita.Application/Features/Purchases/Commands/Create/CreatePurchaseCommandHandler.cs
+++ b/backend/src/Chickquita.Application/Features/Purchases/Commands/Create/CreatePurchaseCommandHandler.cs
@@ -60,16 +60,12 @@ public sealed class CreatePurchaseCommandHandler : IRequestHandler<CreatePurchas
             var tenantId = _currentUserService.TenantId;
 
             // Validate coop reference if provided
-            if (request.CoopId.HasValue)
+            if (request.CoopId.HasValue && !await _coopRepository.ExistsAsync(request.CoopId.Value))
             {
-                var coop = await _coopRepository.GetByIdAsync(request.CoopId.Value);
-                if (coop == null)
-                {
-                    _logger.LogWarning(
-                        "CreatePurchaseCommand: Coop with ID {CoopId} not found",
-                        request.CoopId.Value);
-                    return Result<PurchaseDto>.Failure(Error.NotFound($"Coop with ID {request.CoopId.Value} not found"));
-                }
+                _logger.LogWarning(
+                    "CreatePurchaseCommand: Coop with ID {CoopId} not found",
+                    request.CoopId.Value);
+                return Result<PurchaseDto>.Failure(Error.NotFound($"Coop with ID {request.CoopId.Value} not found"));
             }
 
             // Create the purchase entity

--- a/backend/src/Chickquita.Application/Features/Purchases/Commands/Update/UpdatePurchaseCommandHandler.cs
+++ b/backend/src/Chickquita.Application/Features/Purchases/Commands/Update/UpdatePurchaseCommandHandler.cs
@@ -81,16 +81,12 @@ public sealed class UpdatePurchaseCommandHandler : IRequestHandler<UpdatePurchas
             }
 
             // Validate coop reference if provided
-            if (request.CoopId.HasValue)
+            if (request.CoopId.HasValue && !await _coopRepository.ExistsAsync(request.CoopId.Value))
             {
-                var coop = await _coopRepository.GetByIdAsync(request.CoopId.Value);
-                if (coop == null)
-                {
-                    _logger.LogWarning(
-                        "UpdatePurchaseCommand: Coop with ID {CoopId} not found",
-                        request.CoopId.Value);
-                    return Result<PurchaseDto>.Failure(Error.NotFound($"Coop with ID {request.CoopId.Value} not found"));
-                }
+                _logger.LogWarning(
+                    "UpdatePurchaseCommand: Coop with ID {CoopId} not found",
+                    request.CoopId.Value);
+                return Result<PurchaseDto>.Failure(Error.NotFound($"Coop with ID {request.CoopId.Value} not found"));
             }
 
             // Update the purchase entity

--- a/backend/src/Chickquita.Application/Interfaces/ICoopRepository.cs
+++ b/backend/src/Chickquita.Application/Interfaces/ICoopRepository.cs
@@ -42,6 +42,13 @@ public interface ICoopRepository
     Task DeleteAsync(Guid id);
 
     /// <summary>
+    /// Checks if a coop with the specified ID exists for the current tenant.
+    /// </summary>
+    /// <param name="id">The coop ID to check</param>
+    /// <returns>True if the coop exists, false otherwise</returns>
+    Task<bool> ExistsAsync(Guid id);
+
+    /// <summary>
     /// Checks if a coop with the specified name already exists for the current tenant.
     /// </summary>
     /// <param name="name">The coop name to check</param>

--- a/backend/src/Chickquita.Application/Interfaces/IFlockRepository.cs
+++ b/backend/src/Chickquita.Application/Interfaces/IFlockRepository.cs
@@ -58,6 +58,13 @@ public interface IFlockRepository
     Task DeleteAsync(Guid id);
 
     /// <summary>
+    /// Checks if a flock with the specified ID exists for the current tenant.
+    /// </summary>
+    /// <param name="id">The flock ID to check</param>
+    /// <returns>True if the flock exists, false otherwise</returns>
+    Task<bool> ExistsAsync(Guid id);
+
+    /// <summary>
     /// Checks if a flock with the specified identifier already exists within a coop for the current tenant.
     /// </summary>
     /// <param name="coopId">The coop ID</param>

--- a/backend/src/Chickquita.Infrastructure/Repositories/CoopRepository.cs
+++ b/backend/src/Chickquita.Infrastructure/Repositories/CoopRepository.cs
@@ -79,6 +79,10 @@ public class CoopRepository : ICoopRepository
     }
 
     /// <inheritdoc />
+    public Task<bool> ExistsAsync(Guid id)
+        => _context.Coops.AnyAsync(c => c.Id == id);
+
+    /// <inheritdoc />
     public async Task<bool> ExistsByNameAsync(string name)
     {
         if (string.IsNullOrWhiteSpace(name))

--- a/backend/src/Chickquita.Infrastructure/Repositories/FlockRepository.cs
+++ b/backend/src/Chickquita.Infrastructure/Repositories/FlockRepository.cs
@@ -138,6 +138,10 @@ public class FlockRepository : IFlockRepository
     }
 
     /// <inheritdoc />
+    public Task<bool> ExistsAsync(Guid id)
+        => _context.Flocks.AnyAsync(f => f.Id == id);
+
+    /// <inheritdoc />
     public async Task<bool> ExistsByIdentifierInCoopAsync(Guid coopId, string identifier)
     {
         if (string.IsNullOrWhiteSpace(identifier))

--- a/backend/tests/Chickquita.Application.Tests/Features/DailyRecords/Queries/GetDailyRecordsQueryHandlerTests.cs
+++ b/backend/tests/Chickquita.Application.Tests/Features/DailyRecords/Queries/GetDailyRecordsQueryHandlerTests.cs
@@ -134,13 +134,12 @@ public class GetDailyRecordsQueryHandlerTests
             EndDate = null
         };
 
-        var flock = Flock.Create(tenantId, coopId, "Test Flock", DateTime.UtcNow.AddDays(-30), 10, 2, 5);
         var record1 = DailyRecord.Create(tenantId, flockId, DateTime.UtcNow.AddDays(-5), 10);
         var record2 = DailyRecord.Create(tenantId, flockId, DateTime.UtcNow.AddDays(-3), 12);
 
         _mockCurrentUserService.Setup(x => x.IsAuthenticated).Returns(true);
         _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
-        _mockFlockRepository.Setup(x => x.GetByIdAsync(flockId)).ReturnsAsync(flock);
+        _mockFlockRepository.Setup(x => x.ExistsAsync(flockId)).ReturnsAsync(true);
         _mockDailyRecordRepository.Setup(x => x.GetByFlockIdAsync(flockId))
             .ReturnsAsync(new List<DailyRecord> { record1, record2 });
 
@@ -162,7 +161,7 @@ public class GetDailyRecordsQueryHandlerTests
         result.Value.Should().HaveCount(2);
         result.Value.Should().AllSatisfy(r => r.FlockId.Should().Be(flockId));
 
-        _mockFlockRepository.Verify(x => x.GetByIdAsync(flockId), Times.Once);
+        _mockFlockRepository.Verify(x => x.ExistsAsync(flockId), Times.Once);
         _mockDailyRecordRepository.Verify(x => x.GetByFlockIdAsync(flockId), Times.Once);
     }
 
@@ -183,13 +182,12 @@ public class GetDailyRecordsQueryHandlerTests
             EndDate = endDate
         };
 
-        var flock = Flock.Create(tenantId, coopId, "Test Flock", DateTime.UtcNow.AddDays(-30), 10, 2, 5);
         var record1 = DailyRecord.Create(tenantId, flockId, startDate.AddDays(1), 10);
         var record2 = DailyRecord.Create(tenantId, flockId, startDate.AddDays(3), 12);
 
         _mockCurrentUserService.Setup(x => x.IsAuthenticated).Returns(true);
         _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
-        _mockFlockRepository.Setup(x => x.GetByIdAsync(flockId)).ReturnsAsync(flock);
+        _mockFlockRepository.Setup(x => x.ExistsAsync(flockId)).ReturnsAsync(true);
         _mockDailyRecordRepository.Setup(x => x.GetByFlockIdAndDateRangeAsync(flockId, startDate, endDate))
             .ReturnsAsync(new List<DailyRecord> { record1, record2 });
 
@@ -210,7 +208,7 @@ public class GetDailyRecordsQueryHandlerTests
         result.Value.Should().NotBeNull();
         result.Value.Should().HaveCount(2);
 
-        _mockFlockRepository.Verify(x => x.GetByIdAsync(flockId), Times.Once);
+        _mockFlockRepository.Verify(x => x.ExistsAsync(flockId), Times.Once);
         _mockDailyRecordRepository.Verify(x => x.GetByFlockIdAndDateRangeAsync(flockId, startDate, endDate), Times.Once);
     }
 
@@ -230,7 +228,6 @@ public class GetDailyRecordsQueryHandlerTests
             EndDate = null
         };
 
-        var flock = Flock.Create(tenantId, coopId, "Test Flock", DateTime.UtcNow.AddDays(-30), 10, 2, 5);
 
         // Create records: some before startDate (should be excluded), some after (should be included)
         var recordBeforeStart = DailyRecord.Create(tenantId, flockId, startDate.AddDays(-5), 8);
@@ -239,7 +236,7 @@ public class GetDailyRecordsQueryHandlerTests
 
         _mockCurrentUserService.Setup(x => x.IsAuthenticated).Returns(true);
         _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
-        _mockFlockRepository.Setup(x => x.GetByIdAsync(flockId)).ReturnsAsync(flock);
+        _mockFlockRepository.Setup(x => x.ExistsAsync(flockId)).ReturnsAsync(true);
 
         // Repository returns all records for the flock
         _mockDailyRecordRepository.Setup(x => x.GetByFlockIdAsync(flockId))
@@ -286,7 +283,6 @@ public class GetDailyRecordsQueryHandlerTests
             EndDate = endDate
         };
 
-        var flock = Flock.Create(tenantId, coopId, "Test Flock", DateTime.UtcNow.AddDays(-30), 10, 2, 5);
 
         // Create records: some before endDate (should be included), some after (should be excluded)
         var recordBeforeEnd = DailyRecord.Create(tenantId, flockId, endDate.AddDays(-2), 8);
@@ -295,7 +291,7 @@ public class GetDailyRecordsQueryHandlerTests
 
         _mockCurrentUserService.Setup(x => x.IsAuthenticated).Returns(true);
         _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
-        _mockFlockRepository.Setup(x => x.GetByIdAsync(flockId)).ReturnsAsync(flock);
+        _mockFlockRepository.Setup(x => x.ExistsAsync(flockId)).ReturnsAsync(true);
 
         // Repository returns all records for the flock
         _mockDailyRecordRepository.Setup(x => x.GetByFlockIdAsync(flockId))
@@ -496,8 +492,7 @@ public class GetDailyRecordsQueryHandlerTests
 
         _mockCurrentUserService.Setup(x => x.IsAuthenticated).Returns(true);
         _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
-        _mockFlockRepository.Setup(x => x.GetByIdAsync(flockId))
-            .ReturnsAsync((Flock?)null);
+        _mockFlockRepository.Setup(x => x.ExistsAsync(flockId)).ReturnsAsync(false);
 
         // Act
         var result = await _handler.Handle(query, CancellationToken.None);
@@ -508,7 +503,7 @@ public class GetDailyRecordsQueryHandlerTests
         result.Error.Code.Should().Be("Error.NotFound");
         result.Error.Message.Should().Be("Flock not found");
 
-        _mockFlockRepository.Verify(x => x.GetByIdAsync(flockId), Times.Once);
+        _mockFlockRepository.Verify(x => x.ExistsAsync(flockId), Times.Once);
         _mockDailyRecordRepository.Verify(x => x.GetByFlockIdAsync(It.IsAny<Guid>()), Times.Never);
     }
 

--- a/backend/tests/Chickquita.Application.Tests/Features/Flocks/Commands/CreateFlockCommandHandlerTests.cs
+++ b/backend/tests/Chickquita.Application.Tests/Features/Flocks/Commands/CreateFlockCommandHandlerTests.cs
@@ -62,11 +62,9 @@ public class CreateFlockCommandHandlerTests
             Notes = "First batch"
         };
 
-        var coop = Coop.Create(tenantId, "Main Coop", "North Field");
         _mockCurrentUserService.Setup(x => x.IsAuthenticated).Returns(true);
         _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
-        _mockCoopRepository.Setup(x => x.GetByIdAsync(coopId))
-            .ReturnsAsync(coop);
+        _mockCoopRepository.Setup(x => x.ExistsAsync(coopId)).ReturnsAsync(true);
         _mockFlockRepository.Setup(x => x.ExistsByIdentifierInCoopAsync(coopId, command.Identifier))
             .ReturnsAsync(false);
 
@@ -113,7 +111,7 @@ public class CreateFlockCommandHandlerTests
         result.Value.TenantId.Should().Be(tenantId);
         result.Value.IsActive.Should().BeTrue();
 
-        _mockCoopRepository.Verify(x => x.GetByIdAsync(coopId), Times.Once);
+        _mockCoopRepository.Verify(x => x.ExistsAsync(coopId), Times.Once);
         _mockFlockRepository.Verify(x => x.ExistsByIdentifierInCoopAsync(coopId, command.Identifier), Times.Once);
         _mockFlockRepository.Verify(x => x.AddAsync(It.IsAny<Flock>()), Times.Once);
         _mockMapper.Verify(x => x.Map<FlockDto>(It.IsAny<Flock>()), Times.Once);
@@ -135,10 +133,9 @@ public class CreateFlockCommandHandlerTests
             InitialChicks = 0
         };
 
-        var coop = Coop.Create(tenantId, "Main Coop", "North Field");
         _mockCurrentUserService.Setup(x => x.IsAuthenticated).Returns(true);
         _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
-        _mockCoopRepository.Setup(x => x.GetByIdAsync(coopId)).ReturnsAsync(coop);
+        _mockCoopRepository.Setup(x => x.ExistsAsync(coopId)).ReturnsAsync(true);
         _mockFlockRepository.Setup(x => x.ExistsByIdentifierInCoopAsync(coopId, command.Identifier))
             .ReturnsAsync(false);
 
@@ -192,10 +189,9 @@ public class CreateFlockCommandHandlerTests
             Notes = null
         };
 
-        var coop = Coop.Create(tenantId, "Main Coop", "North Field");
         _mockCurrentUserService.Setup(x => x.IsAuthenticated).Returns(true);
         _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
-        _mockCoopRepository.Setup(x => x.GetByIdAsync(coopId)).ReturnsAsync(coop);
+        _mockCoopRepository.Setup(x => x.ExistsAsync(coopId)).ReturnsAsync(true);
         _mockFlockRepository.Setup(x => x.ExistsByIdentifierInCoopAsync(coopId, command.Identifier))
             .ReturnsAsync(false);
 
@@ -243,10 +239,9 @@ public class CreateFlockCommandHandlerTests
             InitialChicks = 3
         };
 
-        var coop = Coop.Create(tenantId, "Main Coop", "North Field");
         _mockCurrentUserService.Setup(x => x.IsAuthenticated).Returns(true);
         _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
-        _mockCoopRepository.Setup(x => x.GetByIdAsync(coopId)).ReturnsAsync(coop);
+        _mockCoopRepository.Setup(x => x.ExistsAsync(coopId)).ReturnsAsync(true);
         _mockFlockRepository.Setup(x => x.ExistsByIdentifierInCoopAsync(coopId, command.Identifier))
             .ReturnsAsync(false);
 
@@ -290,10 +285,9 @@ public class CreateFlockCommandHandlerTests
             InitialChicks = 2
         };
 
-        var coop = Coop.Create(tenantId, "Main Coop", "North Field");
         _mockCurrentUserService.Setup(x => x.IsAuthenticated).Returns(true);
         _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
-        _mockCoopRepository.Setup(x => x.GetByIdAsync(coopId)).ReturnsAsync(coop);
+        _mockCoopRepository.Setup(x => x.ExistsAsync(coopId)).ReturnsAsync(true);
         _mockFlockRepository.Setup(x => x.ExistsByIdentifierInCoopAsync(coopId, command.Identifier))
             .ReturnsAsync(false);
 
@@ -336,10 +330,9 @@ public class CreateFlockCommandHandlerTests
             InitialChicks = 2
         };
 
-        var coop = Coop.Create(tenantId, "Main Coop", "North Field");
         _mockCurrentUserService.Setup(x => x.IsAuthenticated).Returns(true);
         _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
-        _mockCoopRepository.Setup(x => x.GetByIdAsync(coopId)).ReturnsAsync(coop);
+        _mockCoopRepository.Setup(x => x.ExistsAsync(coopId)).ReturnsAsync(true);
         _mockFlockRepository.Setup(x => x.ExistsByIdentifierInCoopAsync(coopId, command.Identifier))
             .ReturnsAsync(false);
 
@@ -381,10 +374,9 @@ public class CreateFlockCommandHandlerTests
             InitialChicks = 7
         };
 
-        var coop = Coop.Create(tenantId, "Main Coop", "North Field");
         _mockCurrentUserService.Setup(x => x.IsAuthenticated).Returns(true);
         _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
-        _mockCoopRepository.Setup(x => x.GetByIdAsync(coopId)).ReturnsAsync(coop);
+        _mockCoopRepository.Setup(x => x.ExistsAsync(coopId)).ReturnsAsync(true);
         _mockFlockRepository.Setup(x => x.ExistsByIdentifierInCoopAsync(coopId, command.Identifier))
             .ReturnsAsync(false);
 
@@ -426,10 +418,9 @@ public class CreateFlockCommandHandlerTests
             InitialChicks = 2
         };
 
-        var coop = Coop.Create(tenantId, "Main Coop", "North Field");
         _mockCurrentUserService.Setup(x => x.IsAuthenticated).Returns(true);
         _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
-        _mockCoopRepository.Setup(x => x.GetByIdAsync(coopId)).ReturnsAsync(coop);
+        _mockCoopRepository.Setup(x => x.ExistsAsync(coopId)).ReturnsAsync(true);
         _mockFlockRepository.Setup(x => x.ExistsByIdentifierInCoopAsync(coopId, command.Identifier))
             .ReturnsAsync(false);
 
@@ -473,10 +464,9 @@ public class CreateFlockCommandHandlerTests
             Notes = notes
         };
 
-        var coop = Coop.Create(tenantId, "Main Coop", "North Field");
         _mockCurrentUserService.Setup(x => x.IsAuthenticated).Returns(true);
         _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
-        _mockCoopRepository.Setup(x => x.GetByIdAsync(coopId)).ReturnsAsync(coop);
+        _mockCoopRepository.Setup(x => x.ExistsAsync(coopId)).ReturnsAsync(true);
         _mockFlockRepository.Setup(x => x.ExistsByIdentifierInCoopAsync(coopId, command.Identifier))
             .ReturnsAsync(false);
 
@@ -522,8 +512,7 @@ public class CreateFlockCommandHandlerTests
 
         _mockCurrentUserService.Setup(x => x.IsAuthenticated).Returns(true);
         _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
-        _mockCoopRepository.Setup(x => x.GetByIdAsync(coopId))
-            .ReturnsAsync((Coop?)null); // Coop not found
+        _mockCoopRepository.Setup(x => x.ExistsAsync(coopId)).ReturnsAsync(false);
 
         // Act
         var result = await _handler.Handle(command, CancellationToken.None);
@@ -534,7 +523,7 @@ public class CreateFlockCommandHandlerTests
         result.Error.Code.Should().Be("Error.NotFound");
         result.Error.Message.Should().Be("Coop not found");
 
-        _mockCoopRepository.Verify(x => x.GetByIdAsync(coopId), Times.Once);
+        _mockCoopRepository.Verify(x => x.ExistsAsync(coopId), Times.Once);
         _mockFlockRepository.Verify(x => x.AddAsync(It.IsAny<Flock>()), Times.Never);
     }
 
@@ -558,10 +547,9 @@ public class CreateFlockCommandHandlerTests
             InitialChicks = 0
         };
 
-        var coop = Coop.Create(tenantId, "Main Coop", "North Field");
         _mockCurrentUserService.Setup(x => x.IsAuthenticated).Returns(true);
         _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
-        _mockCoopRepository.Setup(x => x.GetByIdAsync(coopId)).ReturnsAsync(coop);
+        _mockCoopRepository.Setup(x => x.ExistsAsync(coopId)).ReturnsAsync(true);
         _mockFlockRepository.Setup(x => x.ExistsByIdentifierInCoopAsync(coopId, command.Identifier))
             .ReturnsAsync(true); // Simulate duplicate identifier
 
@@ -597,10 +585,9 @@ public class CreateFlockCommandHandlerTests
             InitialChicks = 0
         };
 
-        var coop2 = Coop.Create(tenantId, "Second Coop", "South Field");
         _mockCurrentUserService.Setup(x => x.IsAuthenticated).Returns(true);
         _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
-        _mockCoopRepository.Setup(x => x.GetByIdAsync(coop2Id)).ReturnsAsync(coop2);
+        _mockCoopRepository.Setup(x => x.ExistsAsync(coop2Id)).ReturnsAsync(true);
 
         // The identifier exists in coop1, but not in coop2
         _mockFlockRepository.Setup(x => x.ExistsByIdentifierInCoopAsync(coop2Id, sharedIdentifier))
@@ -663,10 +650,9 @@ public class CreateFlockCommandHandlerTests
             InitialChicks = 0
         };
 
-        var coop = Coop.Create(tenantId, "Main Coop", "North Field");
         _mockCurrentUserService.Setup(x => x.IsAuthenticated).Returns(true);
         _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
-        _mockCoopRepository.Setup(x => x.GetByIdAsync(coopId)).ReturnsAsync(coop);
+        _mockCoopRepository.Setup(x => x.ExistsAsync(coopId)).ReturnsAsync(true);
         _mockFlockRepository.Setup(x => x.ExistsByIdentifierInCoopAsync(coopId, command.Identifier))
             .ReturnsAsync(false);
 
@@ -698,10 +684,9 @@ public class CreateFlockCommandHandlerTests
             InitialChicks = 0
         };
 
-        var coop = Coop.Create(tenantId, "Main Coop", "North Field");
         _mockCurrentUserService.Setup(x => x.IsAuthenticated).Returns(true);
         _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
-        _mockCoopRepository.Setup(x => x.GetByIdAsync(coopId)).ReturnsAsync(coop);
+        _mockCoopRepository.Setup(x => x.ExistsAsync(coopId)).ReturnsAsync(true);
         _mockFlockRepository.Setup(x => x.ExistsByIdentifierInCoopAsync(coopId, command.Identifier))
             .ReturnsAsync(false);
 
@@ -733,10 +718,9 @@ public class CreateFlockCommandHandlerTests
             InitialChicks = 0
         };
 
-        var coop = Coop.Create(tenantId, "Main Coop", "North Field");
         _mockCurrentUserService.Setup(x => x.IsAuthenticated).Returns(true);
         _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
-        _mockCoopRepository.Setup(x => x.GetByIdAsync(coopId)).ReturnsAsync(coop);
+        _mockCoopRepository.Setup(x => x.ExistsAsync(coopId)).ReturnsAsync(true);
         _mockFlockRepository.Setup(x => x.ExistsByIdentifierInCoopAsync(coopId, command.Identifier))
             .ReturnsAsync(false);
 
@@ -768,10 +752,9 @@ public class CreateFlockCommandHandlerTests
             InitialChicks = -3 // Negative count
         };
 
-        var coop = Coop.Create(tenantId, "Main Coop", "North Field");
         _mockCurrentUserService.Setup(x => x.IsAuthenticated).Returns(true);
         _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
-        _mockCoopRepository.Setup(x => x.GetByIdAsync(coopId)).ReturnsAsync(coop);
+        _mockCoopRepository.Setup(x => x.ExistsAsync(coopId)).ReturnsAsync(true);
         _mockFlockRepository.Setup(x => x.ExistsByIdentifierInCoopAsync(coopId, command.Identifier))
             .ReturnsAsync(false);
 
@@ -803,10 +786,9 @@ public class CreateFlockCommandHandlerTests
             InitialChicks = 0
         };
 
-        var coop = Coop.Create(tenantId, "Main Coop", "North Field");
         _mockCurrentUserService.Setup(x => x.IsAuthenticated).Returns(true);
         _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
-        _mockCoopRepository.Setup(x => x.GetByIdAsync(coopId)).ReturnsAsync(coop);
+        _mockCoopRepository.Setup(x => x.ExistsAsync(coopId)).ReturnsAsync(true);
         _mockFlockRepository.Setup(x => x.ExistsByIdentifierInCoopAsync(coopId, command.Identifier))
             .ReturnsAsync(false);
 
@@ -840,10 +822,9 @@ public class CreateFlockCommandHandlerTests
             InitialChicks = 0
         };
 
-        var coop = Coop.Create(tenantId, "Main Coop", "North Field");
         _mockCurrentUserService.Setup(x => x.IsAuthenticated).Returns(true);
         _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
-        _mockCoopRepository.Setup(x => x.GetByIdAsync(coopId)).ReturnsAsync(coop);
+        _mockCoopRepository.Setup(x => x.ExistsAsync(coopId)).ReturnsAsync(true);
         _mockFlockRepository.Setup(x => x.ExistsByIdentifierInCoopAsync(coopId, It.IsAny<string>()))
             .ReturnsAsync(false);
 
@@ -876,10 +857,9 @@ public class CreateFlockCommandHandlerTests
             InitialChicks = 0
         };
 
-        var coop = Coop.Create(tenantId, "Main Coop", "North Field");
         _mockCurrentUserService.Setup(x => x.IsAuthenticated).Returns(true);
         _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
-        _mockCoopRepository.Setup(x => x.GetByIdAsync(coopId)).ReturnsAsync(coop);
+        _mockCoopRepository.Setup(x => x.ExistsAsync(coopId)).ReturnsAsync(true);
         _mockFlockRepository.Setup(x => x.ExistsByIdentifierInCoopAsync(coopId, It.IsAny<string>()))
             .ReturnsAsync(false);
 
@@ -915,10 +895,9 @@ public class CreateFlockCommandHandlerTests
             InitialChicks = 0
         };
 
-        var coop = Coop.Create(tenantId, "Main Coop", "North Field");
         _mockCurrentUserService.Setup(x => x.IsAuthenticated).Returns(true);
         _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
-        _mockCoopRepository.Setup(x => x.GetByIdAsync(coopId)).ReturnsAsync(coop);
+        _mockCoopRepository.Setup(x => x.ExistsAsync(coopId)).ReturnsAsync(true);
         _mockFlockRepository.Setup(x => x.ExistsByIdentifierInCoopAsync(coopId, command.Identifier))
             .ReturnsAsync(false);
         _mockFlockRepository.Setup(x => x.AddAsync(It.IsAny<Flock>()))

--- a/backend/tests/Chickquita.Application.Tests/Features/Flocks/Queries/GetFlocksQueryHandlerTests.cs
+++ b/backend/tests/Chickquita.Application.Tests/Features/Flocks/Queries/GetFlocksQueryHandlerTests.cs
@@ -57,13 +57,12 @@ public class GetFlocksQueryHandlerTests
             IncludeInactive = false
         };
 
-        var coop = Coop.Create(tenantId, "Main Coop", "North Field");
         var flock1 = Flock.Create(tenantId, coopId, "Spring 2024", DateTime.UtcNow.AddDays(-60), 10, 2, 5);
         var flock2 = Flock.Create(tenantId, coopId, "Winter 2024", DateTime.UtcNow.AddDays(-30), 8, 1, 3);
 
         _mockCurrentUserService.Setup(x => x.IsAuthenticated).Returns(true);
         _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
-        _mockCoopRepository.Setup(x => x.GetByIdAsync(coopId)).ReturnsAsync(coop);
+        _mockCoopRepository.Setup(x => x.ExistsAsync(coopId)).ReturnsAsync(true);
         _mockFlockRepository.Setup(x => x.GetByCoopIdAsync(coopId, false))
             .ReturnsAsync(new List<Flock> { flock1, flock2 });
 
@@ -87,7 +86,7 @@ public class GetFlocksQueryHandlerTests
         // Verify ordering by CreatedAt descending (newest first)
         result.Value[0].CreatedAt.Should().BeAfter(result.Value[1].CreatedAt);
 
-        _mockCoopRepository.Verify(x => x.GetByIdAsync(coopId), Times.Once);
+        _mockCoopRepository.Verify(x => x.ExistsAsync(coopId), Times.Once);
         _mockFlockRepository.Verify(x => x.GetByCoopIdAsync(coopId, false), Times.Once);
         _mockMapper.Verify(x => x.Map<List<FlockDto>>(It.IsAny<List<Flock>>()), Times.Once);
     }
@@ -131,7 +130,7 @@ public class GetFlocksQueryHandlerTests
         // Verify ordering by CreatedAt descending (newest first)
         result.Value[0].CreatedAt.Should().BeAfter(result.Value[1].CreatedAt);
 
-        _mockCoopRepository.Verify(x => x.GetByIdAsync(It.IsAny<Guid>()), Times.Never);
+        _mockCoopRepository.Verify(x => x.ExistsAsync(It.IsAny<Guid>()), Times.Never);
         _mockFlockRepository.Verify(x => x.GetAllAsync(false), Times.Once);
         _mockMapper.Verify(x => x.Map<List<FlockDto>>(It.IsAny<List<Flock>>()), Times.Once);
     }
@@ -148,11 +147,10 @@ public class GetFlocksQueryHandlerTests
             IncludeInactive = false
         };
 
-        var coop = Coop.Create(tenantId, "Main Coop", "North Field");
 
         _mockCurrentUserService.Setup(x => x.IsAuthenticated).Returns(true);
         _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
-        _mockCoopRepository.Setup(x => x.GetByIdAsync(coopId)).ReturnsAsync(coop);
+        _mockCoopRepository.Setup(x => x.ExistsAsync(coopId)).ReturnsAsync(true);
         _mockFlockRepository.Setup(x => x.GetByCoopIdAsync(coopId, false))
             .ReturnsAsync(new List<Flock>());
 
@@ -167,7 +165,7 @@ public class GetFlocksQueryHandlerTests
         result.Value.Should().NotBeNull();
         result.Value.Should().BeEmpty();
 
-        _mockCoopRepository.Verify(x => x.GetByIdAsync(coopId), Times.Once);
+        _mockCoopRepository.Verify(x => x.ExistsAsync(coopId), Times.Once);
         _mockFlockRepository.Verify(x => x.GetByCoopIdAsync(coopId, false), Times.Once);
     }
 
@@ -187,12 +185,11 @@ public class GetFlocksQueryHandlerTests
             IncludeInactive = false
         };
 
-        var coop = Coop.Create(tenantId, "Main Coop", "North Field");
         var activeFlock = Flock.Create(tenantId, coopId, "Active Flock", DateTime.UtcNow.AddDays(-30), 10, 2, 5);
 
         _mockCurrentUserService.Setup(x => x.IsAuthenticated).Returns(true);
         _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
-        _mockCoopRepository.Setup(x => x.GetByIdAsync(coopId)).ReturnsAsync(coop);
+        _mockCoopRepository.Setup(x => x.ExistsAsync(coopId)).ReturnsAsync(true);
         _mockFlockRepository.Setup(x => x.GetByCoopIdAsync(coopId, false))
             .ReturnsAsync(new List<Flock> { activeFlock });
 
@@ -228,14 +225,13 @@ public class GetFlocksQueryHandlerTests
             IncludeInactive = true
         };
 
-        var coop = Coop.Create(tenantId, "Main Coop", "North Field");
         var activeFlock = Flock.Create(tenantId, coopId, "Active Flock", DateTime.UtcNow.AddDays(-30), 10, 2, 5);
         var archivedFlock = Flock.Create(tenantId, coopId, "Archived Flock", DateTime.UtcNow.AddDays(-90), 8, 1, 3);
         archivedFlock.Archive();
 
         _mockCurrentUserService.Setup(x => x.IsAuthenticated).Returns(true);
         _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
-        _mockCoopRepository.Setup(x => x.GetByIdAsync(coopId)).ReturnsAsync(coop);
+        _mockCoopRepository.Setup(x => x.ExistsAsync(coopId)).ReturnsAsync(true);
         _mockFlockRepository.Setup(x => x.GetByCoopIdAsync(coopId, true))
             .ReturnsAsync(new List<Flock> { activeFlock, archivedFlock });
 
@@ -277,14 +273,13 @@ public class GetFlocksQueryHandlerTests
             IncludeInactive = false
         };
 
-        var coop = Coop.Create(tenantId, "Main Coop", "North Field");
         var oldestFlock = Flock.Create(tenantId, coopId, "Oldest", DateTime.UtcNow.AddDays(-90), 10, 2, 5);
         var middleFlock = Flock.Create(tenantId, coopId, "Middle", DateTime.UtcNow.AddDays(-60), 8, 1, 3);
         var newestFlock = Flock.Create(tenantId, coopId, "Newest", DateTime.UtcNow.AddDays(-30), 12, 2, 6);
 
         _mockCurrentUserService.Setup(x => x.IsAuthenticated).Returns(true);
         _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
-        _mockCoopRepository.Setup(x => x.GetByIdAsync(coopId)).ReturnsAsync(coop);
+        _mockCoopRepository.Setup(x => x.ExistsAsync(coopId)).ReturnsAsync(true);
         _mockFlockRepository.Setup(x => x.GetByCoopIdAsync(coopId, false))
             .ReturnsAsync(new List<Flock> { oldestFlock, middleFlock, newestFlock });
 
@@ -336,8 +331,7 @@ public class GetFlocksQueryHandlerTests
 
         _mockCurrentUserService.Setup(x => x.IsAuthenticated).Returns(true);
         _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
-        _mockCoopRepository.Setup(x => x.GetByIdAsync(coopId))
-            .ReturnsAsync((Coop?)null);
+        _mockCoopRepository.Setup(x => x.ExistsAsync(coopId)).ReturnsAsync(false);
 
         // Act
         var result = await _handler.Handle(query, CancellationToken.None);
@@ -348,7 +342,7 @@ public class GetFlocksQueryHandlerTests
         result.Error.Code.Should().Be("Error.NotFound");
         result.Error.Message.Should().Be("Coop not found");
 
-        _mockCoopRepository.Verify(x => x.GetByIdAsync(coopId), Times.Once);
+        _mockCoopRepository.Verify(x => x.ExistsAsync(coopId), Times.Once);
         _mockFlockRepository.Verify(x => x.GetByCoopIdAsync(It.IsAny<Guid>(), It.IsAny<bool>()), Times.Never);
     }
 
@@ -368,12 +362,11 @@ public class GetFlocksQueryHandlerTests
             IncludeInactive = false
         };
 
-        var coop = Coop.Create(tenantId, "Main Coop", "North Field");
         var flock = Flock.Create(tenantId, coopId, "Test Flock", DateTime.UtcNow.AddDays(-30), 10, 2, 5);
 
         _mockCurrentUserService.Setup(x => x.IsAuthenticated).Returns(true);
         _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
-        _mockCoopRepository.Setup(x => x.GetByIdAsync(coopId)).ReturnsAsync(coop);
+        _mockCoopRepository.Setup(x => x.ExistsAsync(coopId)).ReturnsAsync(true);
         _mockFlockRepository.Setup(x => x.GetByCoopIdAsync(coopId, false))
             .ReturnsAsync(new List<Flock> { flock });
 
@@ -431,10 +424,9 @@ public class GetFlocksQueryHandlerTests
             IncludeInactive = false
         };
 
-        var coop = Coop.Create(tenantId, "Main Coop", "North Field");
         _mockCurrentUserService.Setup(x => x.IsAuthenticated).Returns(true);
         _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
-        _mockCoopRepository.Setup(x => x.GetByIdAsync(coopId)).ReturnsAsync(coop);
+        _mockCoopRepository.Setup(x => x.ExistsAsync(coopId)).ReturnsAsync(true);
         _mockFlockRepository.Setup(x => x.GetByCoopIdAsync(coopId, false))
             .ThrowsAsync(new Exception("Database connection failed"));
 

--- a/backend/tests/Chickquita.Application.Tests/Features/Purchases/Commands/CreatePurchaseCommandHandlerTests.cs
+++ b/backend/tests/Chickquita.Application.Tests/Features/Purchases/Commands/CreatePurchaseCommandHandlerTests.cs
@@ -131,10 +131,7 @@ public class CreatePurchaseCommandHandlerTests
 
         _mockCurrentUserService.Setup(x => x.IsAuthenticated).Returns(true);
         _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
-
-        var existingCoop = Coop.Create(tenantId, "Main Coop", "North Field");
-        _mockCoopRepository.Setup(x => x.GetByIdAsync(coopId))
-            .ReturnsAsync(existingCoop);
+        _mockCoopRepository.Setup(x => x.ExistsAsync(coopId)).ReturnsAsync(true);
 
         var createdPurchase = Purchase.Create(
             tenantId,
@@ -173,7 +170,7 @@ public class CreatePurchaseCommandHandlerTests
         result.Value.Should().NotBeNull();
         result.Value.CoopId.Should().Be(coopId);
 
-        _mockCoopRepository.Verify(x => x.GetByIdAsync(coopId), Times.Once);
+        _mockCoopRepository.Verify(x => x.ExistsAsync(coopId), Times.Once);
         _mockPurchaseRepository.Verify(x => x.AddAsync(It.IsAny<Purchase>()), Times.Once);
     }
 
@@ -260,8 +257,7 @@ public class CreatePurchaseCommandHandlerTests
 
         _mockCurrentUserService.Setup(x => x.IsAuthenticated).Returns(true);
         _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
-        _mockCoopRepository.Setup(x => x.GetByIdAsync(invalidCoopId))
-            .ReturnsAsync((Coop?)null);
+        _mockCoopRepository.Setup(x => x.ExistsAsync(invalidCoopId)).ReturnsAsync(false);
 
         // Act
         var result = await _handler.Handle(command, CancellationToken.None);
@@ -272,7 +268,7 @@ public class CreatePurchaseCommandHandlerTests
         result.Error.Code.Should().Be("Error.NotFound");
         result.Error.Message.Should().Contain($"Coop with ID {invalidCoopId} not found");
 
-        _mockCoopRepository.Verify(x => x.GetByIdAsync(invalidCoopId), Times.Once);
+        _mockCoopRepository.Verify(x => x.ExistsAsync(invalidCoopId), Times.Once);
         _mockPurchaseRepository.Verify(x => x.AddAsync(It.IsAny<Purchase>()), Times.Never);
     }
 

--- a/backend/tests/Chickquita.Application.Tests/Features/Purchases/Commands/UpdatePurchaseCommandHandlerTests.cs
+++ b/backend/tests/Chickquita.Application.Tests/Features/Purchases/Commands/UpdatePurchaseCommandHandlerTests.cs
@@ -144,10 +144,7 @@ public class UpdatePurchaseCommandHandlerTests
 
         _mockPurchaseRepository.Setup(x => x.GetByIdAsync(purchaseId))
             .ReturnsAsync(existingPurchase);
-
-        var existingCoop = Coop.Create(tenantId, "Main Coop", "North Field");
-        _mockCoopRepository.Setup(x => x.GetByIdAsync(coopId))
-            .ReturnsAsync(existingCoop);
+        _mockCoopRepository.Setup(x => x.ExistsAsync(coopId)).ReturnsAsync(true);
 
         _mockPurchaseRepository.Setup(x => x.UpdateAsync(It.IsAny<Purchase>()))
             .ReturnsAsync(existingPurchase);
@@ -176,7 +173,7 @@ public class UpdatePurchaseCommandHandlerTests
         result.Value.Should().NotBeNull();
         result.Value.CoopId.Should().Be(coopId);
 
-        _mockCoopRepository.Verify(x => x.GetByIdAsync(coopId), Times.Once);
+        _mockCoopRepository.Verify(x => x.ExistsAsync(coopId), Times.Once);
         _mockPurchaseRepository.Verify(x => x.UpdateAsync(It.IsAny<Purchase>()), Times.Once);
     }
 
@@ -252,8 +249,7 @@ public class UpdatePurchaseCommandHandlerTests
 
         _mockPurchaseRepository.Setup(x => x.GetByIdAsync(purchaseId))
             .ReturnsAsync(existingPurchase);
-        _mockCoopRepository.Setup(x => x.GetByIdAsync(invalidCoopId))
-            .ReturnsAsync((Coop?)null);
+        _mockCoopRepository.Setup(x => x.ExistsAsync(invalidCoopId)).ReturnsAsync(false);
 
         // Act
         var result = await _handler.Handle(command, CancellationToken.None);
@@ -264,7 +260,7 @@ public class UpdatePurchaseCommandHandlerTests
         result.Error.Code.Should().Be("Error.NotFound");
         result.Error.Message.Should().Contain($"Coop with ID {invalidCoopId} not found");
 
-        _mockCoopRepository.Verify(x => x.GetByIdAsync(invalidCoopId), Times.Once);
+        _mockCoopRepository.Verify(x => x.ExistsAsync(invalidCoopId), Times.Once);
         _mockPurchaseRepository.Verify(x => x.UpdateAsync(It.IsAny<Purchase>()), Times.Never);
     }
 


### PR DESCRIPTION
## Summary

- Added `ExistsAsync(Guid id)` to `ICoopRepository` and `IFlockRepository` interfaces
- Implemented `ExistsAsync` in `CoopRepository` and `FlockRepository` using `AnyAsync` (no data fetched)
- Replaced `GetByIdAsync` + null-check pattern with `ExistsAsync` in 5 command/query handlers

## Changes

- `ICoopRepository.cs` — added `ExistsAsync(Guid id)`
- `IFlockRepository.cs` — added `ExistsAsync(Guid id)`
- `CoopRepository.cs` — implemented `ExistsAsync` via `AnyAsync`
- `FlockRepository.cs` — implemented `ExistsAsync` via `AnyAsync`
- `CreateFlockCommandHandler.cs` — use `ExistsAsync` for coop check
- `GetFlocksQueryHandler.cs` — use `ExistsAsync` for coop check
- `GetDailyRecordsQueryHandler.cs` — use `ExistsAsync` for flock checks
- `CreatePurchaseCommandHandler.cs` — use `ExistsAsync` for coop check
- `UpdatePurchaseCommandHandler.cs` — use `ExistsAsync` for coop check

## Tests

Updated 4 test files to mock `ExistsAsync` instead of `GetByIdAsync`:
- `CreateFlockCommandHandlerTests.cs`
- `GetFlocksQueryHandlerTests.cs`
- `GetDailyRecordsQueryHandlerTests.cs`
- `CreatePurchaseCommandHandlerTests.cs`
- `UpdatePurchaseCommandHandlerTests.cs`

Closes #94