### PR TITLE
fix: move flock ordering into repository layer (DB-side sort)

### DIFF
--- a/backend/src/Chickquita.Application/Features/Flocks/Queries/GetFlocksQueryHandler.cs
+++ b/backend/src/Chickquita.Application/Features/Flocks/Queries/GetFlocksQueryHandler.cs
@@ -89,10 +89,8 @@ public sealed class GetFlocksQueryHandler : IRequestHandler<GetFlocksQuery, Resu
                 tenantId.Value,
                 request.IncludeInactive);
 
-            // Map to DTOs and sort by creation date (newest first)
-            var flockDtos = _mapper.Map<List<FlockDto>>(flocks)
-                .OrderByDescending(f => f.CreatedAt)
-                .ToList();
+            // Map to DTOs — ordering is handled by the repository (CreatedAt descending)
+            var flockDtos = _mapper.Map<List<FlockDto>>(flocks);
 
             return Result<List<FlockDto>>.Success(flockDtos);
         }

--- a/backend/src/Chickquita.Infrastructure/Repositories/FlockRepository.cs
+++ b/backend/src/Chickquita.Infrastructure/Repositories/FlockRepository.cs
@@ -30,7 +30,7 @@ public class FlockRepository : IFlockRepository
         }
 
         return await query
-            .OrderByDescending(f => f.HatchDate)
+            .OrderByDescending(f => f.CreatedAt)
             .ToListAsync();
     }
 
@@ -47,7 +47,7 @@ public class FlockRepository : IFlockRepository
         }
 
         return await query
-            .OrderByDescending(f => f.HatchDate)
+            .OrderByDescending(f => f.CreatedAt)
             .ToListAsync();
     }
 

--- a/backend/tests/Chickquita.Application.Tests/Features/Flocks/Queries/GetFlocksQueryHandlerTests.cs
+++ b/backend/tests/Chickquita.Application.Tests/Features/Flocks/Queries/GetFlocksQueryHandlerTests.cs
@@ -66,10 +66,11 @@ public class GetFlocksQueryHandlerTests
         _mockFlockRepository.Setup(x => x.GetByCoopIdAsync(coopId, false))
             .ReturnsAsync(new List<Flock> { flock1, flock2 });
 
+        // Repository returns newest first (ordering is DB-side)
         var flockDtos = new List<FlockDto>
         {
-            new FlockDto { Id = flock1.Id, Identifier = "Spring 2024", CreatedAt = DateTime.UtcNow.AddDays(-60) },
-            new FlockDto { Id = flock2.Id, Identifier = "Winter 2024", CreatedAt = DateTime.UtcNow.AddDays(-30) }
+            new FlockDto { Id = flock2.Id, Identifier = "Winter 2024", CreatedAt = DateTime.UtcNow.AddDays(-30) },
+            new FlockDto { Id = flock1.Id, Identifier = "Spring 2024", CreatedAt = DateTime.UtcNow.AddDays(-60) }
         };
 
         _mockMapper.Setup(x => x.Map<List<FlockDto>>(It.IsAny<List<Flock>>()))
@@ -83,7 +84,7 @@ public class GetFlocksQueryHandlerTests
         result.Value.Should().NotBeNull();
         result.Value.Should().HaveCount(2);
 
-        // Verify ordering by CreatedAt descending (newest first)
+        // Ordering (newest first) is guaranteed by the repository
         result.Value[0].CreatedAt.Should().BeAfter(result.Value[1].CreatedAt);
 
         _mockCoopRepository.Verify(x => x.ExistsAsync(coopId), Times.Once);
@@ -110,10 +111,11 @@ public class GetFlocksQueryHandlerTests
         _mockFlockRepository.Setup(x => x.GetAllAsync(false))
             .ReturnsAsync(new List<Flock> { flock1, flock2 });
 
+        // Repository returns newest first (ordering is DB-side)
         var flockDtos = new List<FlockDto>
         {
-            new FlockDto { Id = flock1.Id, Identifier = "Flock A", CreatedAt = DateTime.UtcNow.AddDays(-60) },
-            new FlockDto { Id = flock2.Id, Identifier = "Flock B", CreatedAt = DateTime.UtcNow.AddDays(-30) }
+            new FlockDto { Id = flock2.Id, Identifier = "Flock B", CreatedAt = DateTime.UtcNow.AddDays(-30) },
+            new FlockDto { Id = flock1.Id, Identifier = "Flock A", CreatedAt = DateTime.UtcNow.AddDays(-60) }
         };
 
         _mockMapper.Setup(x => x.Map<List<FlockDto>>(It.IsAny<List<Flock>>()))
@@ -127,7 +129,7 @@ public class GetFlocksQueryHandlerTests
         result.Value.Should().NotBeNull();
         result.Value.Should().HaveCount(2);
 
-        // Verify ordering by CreatedAt descending (newest first)
+        // Ordering (newest first) is guaranteed by the repository
         result.Value[0].CreatedAt.Should().BeAfter(result.Value[1].CreatedAt);
 
         _mockCoopRepository.Verify(x => x.ExistsAsync(It.IsAny<Guid>()), Times.Never);
@@ -283,11 +285,12 @@ public class GetFlocksQueryHandlerTests
         _mockFlockRepository.Setup(x => x.GetByCoopIdAsync(coopId, false))
             .ReturnsAsync(new List<Flock> { oldestFlock, middleFlock, newestFlock });
 
+        // Repository returns newest first (ordering is DB-side)
         var flockDtos = new List<FlockDto>
         {
-            new FlockDto { Id = oldestFlock.Id, Identifier = "Oldest", CreatedAt = DateTime.UtcNow.AddDays(-90) },
+            new FlockDto { Id = newestFlock.Id, Identifier = "Newest", CreatedAt = DateTime.UtcNow.AddDays(-30) },
             new FlockDto { Id = middleFlock.Id, Identifier = "Middle", CreatedAt = DateTime.UtcNow.AddDays(-60) },
-            new FlockDto { Id = newestFlock.Id, Identifier = "Newest", CreatedAt = DateTime.UtcNow.AddDays(-30) }
+            new FlockDto { Id = oldestFlock.Id, Identifier = "Oldest", CreatedAt = DateTime.UtcNow.AddDays(-90) }
         };
 
         _mockMapper.Setup(x => x.Map<List<FlockDto>>(It.IsAny<List<Flock>>()))

--- a/backend/tests/Chickquita.Infrastructure.Tests/Repositories/FlockRepositoryTests.cs
+++ b/backend/tests/Chickquita.Infrastructure.Tests/Repositories/FlockRepositoryTests.cs
@@ -141,6 +141,70 @@ public class FlockRepositoryTests : IDisposable
     }
 
     [Fact]
+    public async Task GetAllAsync_ShouldReturnFlocksOrderedByCreatedAtDescending()
+    {
+        // Arrange: persist three flocks with distinct CreatedAt values via reflection
+        var flockIds = new List<Guid>();
+        var baseTime = DateTime.UtcNow;
+
+        using (var ctx = CreateContext())
+        {
+            var repo = new FlockRepository(ctx);
+
+            var flock1 = Flock.Create(_tenantId, _coopId, "Alpha", DateTime.UtcNow.AddDays(-90), 5, 1, 0);
+            typeof(Flock).GetProperty(nameof(Flock.CreatedAt))!.SetValue(flock1, baseTime.AddDays(-2));
+
+            var flock2 = Flock.Create(_tenantId, _coopId, "Beta", DateTime.UtcNow.AddDays(-60), 6, 1, 0);
+            typeof(Flock).GetProperty(nameof(Flock.CreatedAt))!.SetValue(flock2, baseTime.AddDays(-1));
+
+            var flock3 = Flock.Create(_tenantId, _coopId, "Gamma", DateTime.UtcNow.AddDays(-30), 7, 1, 0);
+            typeof(Flock).GetProperty(nameof(Flock.CreatedAt))!.SetValue(flock3, baseTime);
+
+            ctx.Flocks.AddRange(flock1, flock2, flock3);
+            await ctx.SaveChangesAsync();
+            flockIds.AddRange(new[] { flock1.Id, flock2.Id, flock3.Id });
+        }
+
+        // Act
+        using var readCtx = CreateContext();
+        var result = await new FlockRepository(readCtx).GetAllAsync();
+
+        // Assert: newest (Gamma) first, oldest (Alpha) last
+        result.Should().HaveCount(3);
+        result[0].Identifier.Should().Be("Gamma");
+        result[1].Identifier.Should().Be("Beta");
+        result[2].Identifier.Should().Be("Alpha");
+    }
+
+    [Fact]
+    public async Task GetByCoopIdAsync_ShouldReturnFlocksOrderedByCreatedAtDescending()
+    {
+        // Arrange: persist two flocks for _coopId with distinct CreatedAt values
+        var baseTime = DateTime.UtcNow;
+
+        using (var ctx = CreateContext())
+        {
+            var flock1 = Flock.Create(_tenantId, _coopId, "Older", DateTime.UtcNow.AddDays(-60), 5, 1, 0);
+            typeof(Flock).GetProperty(nameof(Flock.CreatedAt))!.SetValue(flock1, baseTime.AddDays(-1));
+
+            var flock2 = Flock.Create(_tenantId, _coopId, "Newer", DateTime.UtcNow.AddDays(-30), 6, 1, 0);
+            typeof(Flock).GetProperty(nameof(Flock.CreatedAt))!.SetValue(flock2, baseTime);
+
+            ctx.Flocks.AddRange(flock1, flock2);
+            await ctx.SaveChangesAsync();
+        }
+
+        // Act
+        using var readCtx = CreateContext();
+        var result = await new FlockRepository(readCtx).GetByCoopIdAsync(_coopId);
+
+        // Assert: newest first
+        result.Should().HaveCount(2);
+        result[0].Identifier.Should().Be("Newer");
+        result[1].Identifier.Should().Be("Older");
+    }
+
+    [Fact]
     public async Task UpdateAsync_WhenEntityIsDetached_ShouldStillSaveChanges()
     {
         // Arrange: persist a flock in a dedicated context


### PR DESCRIPTION
## Summary

Moves the `OrderByDescending(f => f.CreatedAt)` sort from in-memory (after AutoMapper mapping in the handler) into the EF Core LINQ queries in `FlockRepository`, where it translates to `ORDER BY CreatedAt DESC` in SQL.

## Changes

• `FlockRepository.cs` — replaced `HatchDate` sort with `CreatedAt` sort in both `GetAllAsync` and `GetByCoopIdAsync`
• `GetFlocksQueryHandler.cs` — removed in-memory `.OrderByDescending().ToList()` after mapping; ordering is now the repository's responsibility
• `GetFlocksQueryHandlerTests.cs` — updated 3 tests: mock mapper now returns pre-sorted DTOs (newest first) to match repository contract
• `FlockRepositoryTests.cs` — added 2 new integration tests verifying DB-side ordering in both `GetAllAsync` and `GetByCoopIdAsync` using SQLite in-memory with reflection to set distinct `CreatedAt` values

## Tests

2 new repository integration tests added (`GetAllAsync_ShouldReturnFlocksOrderedByCreatedAtDescending`, `GetByCoopIdAsync_ShouldReturnFlocksOrderedByCreatedAtDescending`). 3 existing handler unit tests updated to align with new contract.

Closes #87