### PR TITLE
refactor: remove empty Class1.cs scaffold file from Application project

### DIFF
--- a/backend/src/Chickquita.Application/Class1.cs
+++ b/backend/src/Chickquita.Application/Class1.cs
@@ -1,6 +1,0 @@
-﻿namespace Chickquita.Application;
-
-public class Class1
-{
-
-}


### PR DESCRIPTION
## Summary

Removes the empty `Class1.cs` scaffold file that was left over from when the `Chickquita.Application` project was created with `dotnet new classlib`. The file contains only an empty class with no members and no usages anywhere in the codebase.

## Changes

- Deleted `backend/src/Chickquita.Application/Class1.cs`

## Tests

No functional changes — the existing test suite continues to cover the Application layer. Build verification via CI.

Closes #98