### PR TITLE
Remove redundant null argument guards from repository methods

### DIFF
--- a/backend/src/Chickquita.Infrastructure/Repositories/CoopRepository.cs
+++ b/backend/src/Chickquita.Infrastructure/Repositories/CoopRepository.cs
@@ -48,11 +48,6 @@ public class CoopRepository : ICoopRepository
     /// <inheritdoc />
     public async Task<Coop> AddAsync(Coop coop)
     {
-        if (coop == null)
-        {
-            throw new ArgumentNullException(nameof(coop));
-        }
-
         await _context.Coops.AddAsync(coop);
         return coop;
     }
@@ -60,11 +55,6 @@ public class CoopRepository : ICoopRepository
     /// <inheritdoc />
     public async Task<Coop> UpdateAsync(Coop coop)
     {
-        if (coop == null)
-        {
-            throw new ArgumentNullException(nameof(coop));
-        }
-
         _context.Coops.Update(coop);
         return coop;
     }

--- a/backend/src/Chickquita.Infrastructure/Repositories/DailyRecordRepository.cs
+++ b/backend/src/Chickquita.Infrastructure/Repositories/DailyRecordRepository.cs
@@ -77,11 +77,6 @@ public class DailyRecordRepository : IDailyRecordRepository
     /// <inheritdoc />
     public async Task<DailyRecord> AddAsync(DailyRecord dailyRecord)
     {
-        if (dailyRecord == null)
-        {
-            throw new ArgumentNullException(nameof(dailyRecord));
-        }
-
         await _context.DailyRecords.AddAsync(dailyRecord);
         return dailyRecord;
     }
@@ -89,11 +84,6 @@ public class DailyRecordRepository : IDailyRecordRepository
     /// <inheritdoc />
     public async Task<DailyRecord> UpdateAsync(DailyRecord dailyRecord)
     {
-        if (dailyRecord == null)
-        {
-            throw new ArgumentNullException(nameof(dailyRecord));
-        }
-
         _context.DailyRecords.Update(dailyRecord);
         return dailyRecord;
     }

--- a/backend/src/Chickquita.Infrastructure/Repositories/FlockHistoryRepository.cs
+++ b/backend/src/Chickquita.Infrastructure/Repositories/FlockHistoryRepository.cs
@@ -33,11 +33,6 @@ public class FlockHistoryRepository : IFlockHistoryRepository
     /// <inheritdoc />
     public async Task<FlockHistory> UpdateAsync(FlockHistory historyEntry)
     {
-        if (historyEntry == null)
-        {
-            throw new ArgumentNullException(nameof(historyEntry));
-        }
-
         _context.FlockHistory.Update(historyEntry);
         return historyEntry;
     }

--- a/backend/src/Chickquita.Infrastructure/Repositories/FlockRepository.cs
+++ b/backend/src/Chickquita.Infrastructure/Repositories/FlockRepository.cs
@@ -69,11 +69,6 @@ public class FlockRepository : IFlockRepository
     /// <inheritdoc />
     public async Task<Flock> AddAsync(Flock flock)
     {
-        if (flock == null)
-        {
-            throw new ArgumentNullException(nameof(flock));
-        }
-
         await _context.Flocks.AddAsync(flock);
         return flock;
     }
@@ -81,11 +76,6 @@ public class FlockRepository : IFlockRepository
     /// <inheritdoc />
     public async Task<Flock> UpdateAsync(Flock flock)
     {
-        if (flock == null)
-        {
-            throw new ArgumentNullException(nameof(flock));
-        }
-
         var entry = _context.Entry(flock);
         if (entry.State == EntityState.Detached)
         {

--- a/backend/src/Chickquita.Infrastructure/Repositories/PurchaseRepository.cs
+++ b/backend/src/Chickquita.Infrastructure/Repositories/PurchaseRepository.cs
@@ -149,11 +149,6 @@ public class PurchaseRepository : IPurchaseRepository
     /// <inheritdoc />
     public async Task<Purchase> AddAsync(Purchase purchase)
     {
-        if (purchase == null)
-        {
-            throw new ArgumentNullException(nameof(purchase));
-        }
-
         await _context.Purchases.AddAsync(purchase);
         return purchase;
     }
@@ -161,11 +156,6 @@ public class PurchaseRepository : IPurchaseRepository
     /// <inheritdoc />
     public async Task<Purchase> UpdateAsync(Purchase purchase)
     {
-        if (purchase == null)
-        {
-            throw new ArgumentNullException(nameof(purchase));
-        }
-
         _context.Purchases.Update(purchase);
         return purchase;
     }

--- a/backend/src/Chickquita.Infrastructure/Repositories/TenantRepository.cs
+++ b/backend/src/Chickquita.Infrastructure/Repositories/TenantRepository.cs
@@ -31,18 +31,12 @@ public class TenantRepository : ITenantRepository
 
     public async Task<Tenant> AddAsync(Tenant tenant)
     {
-        if (tenant == null)
-            throw new ArgumentNullException(nameof(tenant));
-
         await _context.Tenants.AddAsync(tenant);
         return tenant;
     }
 
     public async Task UpdateAsync(Tenant tenant)
     {
-        if (tenant == null)
-            throw new ArgumentNullException(nameof(tenant));
-
         _context.Tenants.Update(tenant);
     }
 

--- a/backend/tests/Chickquita.Infrastructure.Tests/Repositories/DailyRecordRepositoryTests.cs
+++ b/backend/tests/Chickquita.Infrastructure.Tests/Repositories/DailyRecordRepositoryTests.cs
@@ -313,16 +313,6 @@ public class DailyRecordRepositoryTests : IDisposable
         savedRecord.Notes.Should().Be("Test record");
     }
 
-    [Fact]
-    public async Task AddAsync_ThrowsArgumentNullException_WhenRecordIsNull()
-    {
-        // Act
-        var act = async () => await _repository.AddAsync(null!);
-
-        // Assert
-        await act.Should().ThrowAsync<ArgumentNullException>();
-    }
-
     #endregion
 
     #region UpdateAsync Tests
@@ -348,16 +338,6 @@ public class DailyRecordRepositoryTests : IDisposable
         updatedRecord.Should().NotBeNull();
         updatedRecord!.EggCount.Should().Be(15);
         updatedRecord.Notes.Should().Be("Updated notes");
-    }
-
-    [Fact]
-    public async Task UpdateAsync_ThrowsArgumentNullException_WhenRecordIsNull()
-    {
-        // Act
-        var act = async () => await _repository.UpdateAsync(null!);
-
-        // Assert
-        await act.Should().ThrowAsync<ArgumentNullException>();
     }
 
     #endregion

--- a/backend/tests/Chickquita.Infrastructure.Tests/Repositories/PurchaseRepositoryTests.cs
+++ b/backend/tests/Chickquita.Infrastructure.Tests/Repositories/PurchaseRepositoryTests.cs
@@ -384,16 +384,6 @@ public class PurchaseRepositoryTests : IDisposable
         savedPurchase.Notes.Should().Be("Test notes");
     }
 
-    [Fact]
-    public async Task AddAsync_ThrowsArgumentNullException_WhenPurchaseIsNull()
-    {
-        // Act
-        var act = async () => await _repository.AddAsync(null!);
-
-        // Assert
-        await act.Should().ThrowAsync<ArgumentNullException>();
-    }
-
     #endregion
 
     #region UpdateAsync Tests
@@ -426,16 +416,6 @@ public class PurchaseRepositoryTests : IDisposable
         updatedPurchase!.Name.Should().Be("Feed 2");
         updatedPurchase.Amount.Should().Be(150m);
         updatedPurchase.Notes.Should().Be("Updated notes");
-    }
-
-    [Fact]
-    public async Task UpdateAsync_ThrowsArgumentNullException_WhenPurchaseIsNull()
-    {
-        // Act
-        var act = async () => await _repository.UpdateAsync(null!);
-
-        // Assert
-        await act.Should().ThrowAsync<ArgumentNullException>();
     }
 
     #endregion


### PR DESCRIPTION
Closes #101

## Summary

With `<Nullable>enable</Nullable>` set across all projects, method parameters declared as non-nullable reference types cannot receive `null` from well-typed callers. The null checks in `AddAsync`/`UpdateAsync` were dead code — unreachable by design.

### Changes

- Removed `if (x == null) throw ArgumentNullException` guards from `AddAsync`/`UpdateAsync` in:
  - `PurchaseRepository`
  - `CoopRepository`
  - `FlockRepository`
  - `DailyRecordRepository`
  - `TenantRepository`
  - `FlockHistoryRepository`
- Removed the corresponding `ThrowsArgumentNullException` unit tests from `PurchaseRepositoryTests` and `DailyRecordRepositoryTests`

### Not changed

Constructor null guards (e.g. `_context = context ?? throw new ArgumentNullException(...)`) are intentionally kept — they protect against DI misconfiguration which the compiler cannot prevent.

## Test plan
- [x] Existing tests continue to pass (null tests removed, all other tests intact)
- [x] Build passes with no errors