### PR TITLE
docs: add OpenAPI summary/description to all endpoint groups

### DIFF
--- a/backend/src/Chickquita.Api/Endpoints/CoopsEndpoints.cs
+++ b/backend/src/Chickquita.Api/Endpoints/CoopsEndpoints.cs
@@ -17,20 +17,35 @@ public static class CoopsEndpoints
 
         group.MapGet("", GetCoops)
             .WithName("GetCoops")
-            .WithOpenApi()
+            .WithOpenApi(op =>
+            {
+                op.Summary = "Get all coops";
+                op.Description = "Retrieves all coops for the current tenant. Optionally include archived coops.";
+                return op;
+            })
             .Produces<List<CoopDto>>()
             .Produces(StatusCodes.Status401Unauthorized);
 
         group.MapGet("/{id:guid}", GetCoopById)
             .WithName("GetCoopById")
-            .WithOpenApi()
+            .WithOpenApi(op =>
+            {
+                op.Summary = "Get coop by ID";
+                op.Description = "Retrieves a specific coop by its ID.";
+                return op;
+            })
             .Produces<CoopDto>()
             .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status404NotFound);
 
         group.MapPost("", CreateCoop)
             .WithName("CreateCoop")
-            .WithOpenApi()
+            .WithOpenApi(op =>
+            {
+                op.Summary = "Create a new coop";
+                op.Description = "Creates a new coop for the current tenant.";
+                return op;
+            })
             .Produces<CoopDto>(StatusCodes.Status201Created)
             .Produces(StatusCodes.Status400BadRequest)
             .Produces(StatusCodes.Status401Unauthorized)
@@ -38,7 +53,12 @@ public static class CoopsEndpoints
 
         group.MapPut("/{id:guid}", UpdateCoop)
             .WithName("UpdateCoop")
-            .WithOpenApi()
+            .WithOpenApi(op =>
+            {
+                op.Summary = "Update a coop";
+                op.Description = "Updates the name or description of an existing coop.";
+                return op;
+            })
             .Produces<CoopDto>()
             .Produces(StatusCodes.Status400BadRequest)
             .Produces(StatusCodes.Status401Unauthorized)
@@ -47,7 +67,12 @@ public static class CoopsEndpoints
 
         group.MapDelete("/{id:guid}", DeleteCoop)
             .WithName("DeleteCoop")
-            .WithOpenApi()
+            .WithOpenApi(op =>
+            {
+                op.Summary = "Delete a coop";
+                op.Description = "Permanently deletes the specified coop. Fails if the coop has active flocks.";
+                return op;
+            })
             .Produces<bool>()
             .Produces(StatusCodes.Status400BadRequest)
             .Produces(StatusCodes.Status401Unauthorized)
@@ -55,7 +80,12 @@ public static class CoopsEndpoints
 
         group.MapPatch("/{id:guid}/archive", ArchiveCoop)
             .WithName("ArchiveCoop")
-            .WithOpenApi()
+            .WithOpenApi(op =>
+            {
+                op.Summary = "Archive a coop";
+                op.Description = "Archives the specified coop, marking it as inactive.";
+                return op;
+            })
             .Produces<bool>()
             .Produces(StatusCodes.Status400BadRequest)
             .Produces(StatusCodes.Status401Unauthorized)

--- a/backend/src/Chickquita.Api/Endpoints/DailyRecordsEndpoints.cs
+++ b/backend/src/Chickquita.Api/Endpoints/DailyRecordsEndpoints.cs
@@ -23,7 +23,12 @@ public static class DailyRecordsEndpoints
         // Also available as GET /api/flocks/{flockId}/daily-records
         dailyRecordsGroup.MapGet("", GetDailyRecords)
             .WithName("GetDailyRecords")
-            .WithOpenApi()
+            .WithOpenApi(op =>
+            {
+                op.Summary = "Get all daily records";
+                op.Description = "Retrieves daily egg production records for the current tenant. Optionally filter by flock ID and/or date range.";
+                return op;
+            })
             .Produces<List<DailyRecordDto>>()
             .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status404NotFound);
@@ -31,7 +36,12 @@ public static class DailyRecordsEndpoints
         // GET /api/flocks/{flockId}/daily-records - Get all daily records for a specific flock
         flocksGroup.MapGet("/{flockId:guid}/daily-records", GetDailyRecordsByFlock)
             .WithName("GetDailyRecordsByFlock")
-            .WithOpenApi()
+            .WithOpenApi(op =>
+            {
+                op.Summary = "Get daily records by flock";
+                op.Description = "Retrieves all daily egg production records for the specified flock, optionally filtered by date range.";
+                return op;
+            })
             .Produces<List<DailyRecordDto>>()
             .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status404NotFound);
@@ -39,7 +49,12 @@ public static class DailyRecordsEndpoints
         // POST /api/flocks/{flockId}/daily-records - Create a new daily record for a specific flock
         flocksGroup.MapPost("/{flockId:guid}/daily-records", CreateDailyRecord)
             .WithName("CreateDailyRecord")
-            .WithOpenApi()
+            .WithOpenApi(op =>
+            {
+                op.Summary = "Create a daily record";
+                op.Description = "Records a new daily egg collection for the specified flock.";
+                return op;
+            })
             .Produces<DailyRecordDto>(StatusCodes.Status201Created)
             .Produces(StatusCodes.Status400BadRequest)
             .Produces(StatusCodes.Status401Unauthorized)
@@ -48,7 +63,12 @@ public static class DailyRecordsEndpoints
         // PUT /api/daily-records/{id} - Update a daily record
         dailyRecordsGroup.MapPut("/{id:guid}", UpdateDailyRecord)
             .WithName("UpdateDailyRecord")
-            .WithOpenApi()
+            .WithOpenApi(op =>
+            {
+                op.Summary = "Update a daily record";
+                op.Description = "Updates an existing daily egg production record.";
+                return op;
+            })
             .Produces<DailyRecordDto>()
             .Produces(StatusCodes.Status400BadRequest)
             .Produces(StatusCodes.Status401Unauthorized)
@@ -57,7 +77,12 @@ public static class DailyRecordsEndpoints
         // DELETE /api/daily-records/{id} - Delete a daily record
         dailyRecordsGroup.MapDelete("/{id:guid}", DeleteDailyRecord)
             .WithName("DeleteDailyRecord")
-            .WithOpenApi()
+            .WithOpenApi(op =>
+            {
+                op.Summary = "Delete a daily record";
+                op.Description = "Permanently deletes the specified daily egg production record.";
+                return op;
+            })
             .Produces(StatusCodes.Status204NoContent)
             .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status404NotFound);

--- a/backend/src/Chickquita.Api/Endpoints/FlockHistoryEndpoints.cs
+++ b/backend/src/Chickquita.Api/Endpoints/FlockHistoryEndpoints.cs
@@ -22,7 +22,12 @@ public static class FlockHistoryEndpoints
         // GET /api/flocks/{id}/history - Get full flock change history timeline
         flocksGroup.MapGet("/{id:guid}/history", GetFlockHistory)
             .WithName("GetFlockHistory")
-            .WithOpenApi()
+            .WithOpenApi(op =>
+            {
+                op.Summary = "Get flock history";
+                op.Description = "Retrieves the full change history timeline for the specified flock.";
+                return op;
+            })
             .Produces<List<FlockHistoryDto>>()
             .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status404NotFound);
@@ -30,7 +35,12 @@ public static class FlockHistoryEndpoints
         // PATCH /api/flock-history/{id}/notes - Update notes on history record
         historyGroup.MapPatch("/{id:guid}/notes", UpdateFlockHistoryNotes)
             .WithName("UpdateFlockHistoryNotes")
-            .WithOpenApi()
+            .WithOpenApi(op =>
+            {
+                op.Summary = "Update history entry notes";
+                op.Description = "Updates the notes field on a flock history entry.";
+                return op;
+            })
             .Produces<FlockHistoryDto>()
             .Produces(StatusCodes.Status400BadRequest)
             .Produces(StatusCodes.Status401Unauthorized)

--- a/backend/src/Chickquita.Api/Endpoints/FlocksEndpoints.cs
+++ b/backend/src/Chickquita.Api/Endpoints/FlocksEndpoints.cs
@@ -23,7 +23,12 @@ public static class FlocksEndpoints
         // Also available as GET /api/coops/{coopId}/flocks
         flocksGroup.MapGet("", GetFlocks)
             .WithName("GetFlocks")
-            .WithOpenApi()
+            .WithOpenApi(op =>
+            {
+                op.Summary = "Get all flocks";
+                op.Description = "Retrieves all flocks for the current tenant. Optionally filter by coop ID or include inactive/archived flocks.";
+                return op;
+            })
             .Produces<List<FlockDto>>()
             .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status404NotFound);
@@ -31,7 +36,12 @@ public static class FlocksEndpoints
         // GET /api/coops/{coopId}/flocks - Get all flocks for a specific coop
         coopsGroup.MapGet("/{coopId:guid}/flocks", GetFlocksByCoop)
             .WithName("GetFlocksByCoop")
-            .WithOpenApi()
+            .WithOpenApi(op =>
+            {
+                op.Summary = "Get flocks by coop";
+                op.Description = "Retrieves all flocks belonging to the specified coop.";
+                return op;
+            })
             .Produces<List<FlockDto>>()
             .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status404NotFound);
@@ -39,7 +49,12 @@ public static class FlocksEndpoints
         // POST /api/coops/{coopId}/flocks - Create a new flock under a specific coop
         coopsGroup.MapPost("/{coopId:guid}/flocks", CreateFlock)
             .WithName("CreateFlock")
-            .WithOpenApi()
+            .WithOpenApi(op =>
+            {
+                op.Summary = "Create a new flock";
+                op.Description = "Creates a new flock under the specified coop.";
+                return op;
+            })
             .Produces<FlockDto>(StatusCodes.Status201Created)
             .Produces(StatusCodes.Status400BadRequest)
             .Produces(StatusCodes.Status401Unauthorized)
@@ -48,7 +63,12 @@ public static class FlocksEndpoints
         // GET /api/flocks/{id} - Get a specific flock by ID
         flocksGroup.MapGet("/{id:guid}", GetFlockById)
             .WithName("GetFlockById")
-            .WithOpenApi()
+            .WithOpenApi(op =>
+            {
+                op.Summary = "Get flock by ID";
+                op.Description = "Retrieves a specific flock by its ID, including its change history.";
+                return op;
+            })
             .Produces<FlockDto>()
             .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status404NotFound);
@@ -56,7 +76,12 @@ public static class FlocksEndpoints
         // PUT /api/flocks/{id} - Update a flock
         flocksGroup.MapPut("/{id:guid}", UpdateFlock)
             .WithName("UpdateFlock")
-            .WithOpenApi()
+            .WithOpenApi(op =>
+            {
+                op.Summary = "Update a flock";
+                op.Description = "Updates the name, breed, or other properties of an existing flock.";
+                return op;
+            })
             .Produces<FlockDto>()
             .Produces(StatusCodes.Status400BadRequest)
             .Produces(StatusCodes.Status401Unauthorized)
@@ -65,7 +90,12 @@ public static class FlocksEndpoints
         // POST /api/flocks/{id}/archive - Archive a flock
         flocksGroup.MapPost("/{id:guid}/archive", ArchiveFlock)
             .WithName("ArchiveFlock")
-            .WithOpenApi()
+            .WithOpenApi(op =>
+            {
+                op.Summary = "Archive a flock";
+                op.Description = "Archives the specified flock, marking it as inactive.";
+                return op;
+            })
             .Produces<FlockDto>()
             .Produces(StatusCodes.Status400BadRequest)
             .Produces(StatusCodes.Status401Unauthorized)
@@ -74,7 +104,12 @@ public static class FlocksEndpoints
         // POST /api/flocks/{id}/mature-chicks - Mature chicks into hens/roosters
         flocksGroup.MapPost("/{id:guid}/mature-chicks", MatureChicks)
             .WithName("MatureChicks")
-            .WithOpenApi()
+            .WithOpenApi(op =>
+            {
+                op.Summary = "Mature chicks";
+                op.Description = "Converts chicks in the flock to hens or roosters based on the provided quantities.";
+                return op;
+            })
             .Produces<FlockDto>()
             .Produces(StatusCodes.Status400BadRequest)
             .Produces(StatusCodes.Status401Unauthorized)
@@ -83,7 +118,12 @@ public static class FlocksEndpoints
         // PUT /api/flocks/{id}/composition - Update flock composition (hens, roosters, chicks)
         flocksGroup.MapPut("/{id:guid}/composition", UpdateFlockComposition)
             .WithName("UpdateFlockComposition")
-            .WithOpenApi()
+            .WithOpenApi(op =>
+            {
+                op.Summary = "Update flock composition";
+                op.Description = "Updates the number of hens, roosters, and chicks in the flock.";
+                return op;
+            })
             .Produces<FlockDto>()
             .Produces(StatusCodes.Status400BadRequest)
             .Produces(StatusCodes.Status401Unauthorized)

--- a/backend/src/Chickquita.Api/Endpoints/StatisticsEndpoints.cs
+++ b/backend/src/Chickquita.Api/Endpoints/StatisticsEndpoints.cs
@@ -23,14 +23,24 @@ public static class StatisticsEndpoints
 
         group.MapGet("/dashboard", GetDashboardStats)
             .WithName("GetDashboardStats")
-            .WithOpenApi()
+            .WithOpenApi(op =>
+            {
+                op.Summary = "Get dashboard statistics";
+                op.Description = "Returns aggregated statistics for the current tenant: total coops, active flocks, total hens, and total animals.";
+                return op;
+            })
             .Produces<DashboardStatsDto>()
             .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status400BadRequest);
 
         group.MapGet("", GetStatistics)
             .WithName("GetStatistics")
-            .WithOpenApi()
+            .WithOpenApi(op =>
+            {
+                op.Summary = "Get detailed statistics";
+                op.Description = "Returns detailed statistics for a given date range, including cost breakdown, production trends, cost per egg, and flock productivity. Optionally filter by coop or flock.";
+                return op;
+            })
             .Produces<StatisticsDto>()
             .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status400BadRequest);

--- a/backend/src/Chickquita.Api/Endpoints/UsersEndpoints.cs
+++ b/backend/src/Chickquita.Api/Endpoints/UsersEndpoints.cs
@@ -16,7 +16,12 @@ public static class UsersEndpoints
 
         group.MapGet("/me", GetCurrentUser)
             .WithName("GetCurrentUser")
-            .WithOpenApi()
+            .WithOpenApi(op =>
+            {
+                op.Summary = "Get current user";
+                op.Description = "Returns the profile of the currently authenticated user.";
+                return op;
+            })
             .Produces<UserDto>()
             .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status404NotFound);


### PR DESCRIPTION
## Summary

All endpoint groups now have consistent OpenAPI documentation matching the pattern already used in `PurchasesEndpoints`.

## Changes

- `FlocksEndpoints.cs` — added Summary + Description to all 8 endpoints
- `CoopsEndpoints.cs` — added Summary + Description to all 6 endpoints
- `DailyRecordsEndpoints.cs` — added Summary + Description to all 5 endpoints
- `FlockHistoryEndpoints.cs` — added Summary + Description to both endpoints
- `StatisticsEndpoints.cs` — added Summary + Description to both endpoints
- `UsersEndpoints.cs` — added Summary + Description to the single endpoint

All endpoints now use `WithOpenApi(op => { op.Summary = "..."; op.Description = "..."; return op; })` consistently.

`WebhooksEndpoints.cs` was intentionally left without `WithOpenApi()` — webhook endpoints are typically excluded from Swagger UI.

## Tests

No new tests required — this is a documentation-only change affecting OpenAPI metadata strings. Existing endpoint integration tests continue to cover the HTTP behavior.

Closes #102