### PR TITLE
fix: separate query/command handler files into dedicated files

### DIFF
--- a/backend/src/Chickquita.Application/Features/Coops/Queries/GetCoopByIdQuery.cs
+++ b/backend/src/Chickquita.Application/Features/Coops/Queries/GetCoopByIdQuery.cs
@@ -1,87 +1,10 @@
-using AutoMapper;
 using Chickquita.Domain.Common;
 using Chickquita.Application.DTOs;
-using Chickquita.Application.Interfaces;
 using MediatR;
-using Microsoft.Extensions.Logging;
 
 namespace Chickquita.Application.Features.Coops.Queries;
 
 public record GetCoopByIdQuery : IRequest<Result<CoopDto>>
 {
     public Guid Id { get; init; }
-}
-
-public class GetCoopByIdQueryHandler : IRequestHandler<GetCoopByIdQuery, Result<CoopDto>>
-{
-    private readonly ICoopRepository _coopRepository;
-    private readonly ICurrentUserService _currentUserService;
-    private readonly IMapper _mapper;
-    private readonly ILogger<GetCoopByIdQueryHandler> _logger;
-
-    public GetCoopByIdQueryHandler(
-        ICoopRepository coopRepository,
-        ICurrentUserService currentUserService,
-        IMapper mapper,
-        ILogger<GetCoopByIdQueryHandler> logger)
-    {
-        _coopRepository = coopRepository;
-        _currentUserService = currentUserService;
-        _mapper = mapper;
-        _logger = logger;
-    }
-
-    public async Task<Result<CoopDto>> Handle(GetCoopByIdQuery request, CancellationToken cancellationToken)
-    {
-        _logger.LogInformation("Processing GetCoopByIdQuery for coop {CoopId}", request.Id);
-
-        try
-        {
-            // Verify user is authenticated
-            if (!_currentUserService.IsAuthenticated)
-            {
-                _logger.LogWarning("GetCoopByIdQuery: User is not authenticated");
-                return Result<CoopDto>.Failure(Error.Unauthorized("User is not authenticated"));
-            }
-
-            // Get current tenant ID
-            var tenantId = _currentUserService.TenantId;
-            if (!tenantId.HasValue)
-            {
-                _logger.LogWarning("GetCoopByIdQuery: Tenant ID not found");
-                return Result<CoopDto>.Failure(Error.Unauthorized("Tenant not found"));
-            }
-
-            // Retrieve coop by ID (tenant isolation is handled by RLS and global query filter)
-            var coop = await _coopRepository.GetByIdAsync(request.Id);
-
-            if (coop == null)
-            {
-                _logger.LogInformation("Coop {CoopId} not found for tenant {TenantId}", request.Id, tenantId.Value);
-                return Result<CoopDto>.Failure(Error.NotFound("Coop not found"));
-            }
-
-            _logger.LogInformation(
-                "Successfully retrieved coop {CoopId} for tenant {TenantId}",
-                request.Id,
-                tenantId.Value);
-
-            var coopDto = _mapper.Map<CoopDto>(coop);
-
-            // Populate flocks count
-            coopDto.FlocksCount = await _coopRepository.GetFlocksCountAsync(coopDto.Id);
-
-            return Result<CoopDto>.Success(coopDto);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(
-                ex,
-                "Error occurred while retrieving coop {CoopId}",
-                request.Id);
-
-            return Result<CoopDto>.Failure(
-                Error.Failure("An unexpected error occurred. Please try again."));
-        }
-    }
 }

--- a/backend/src/Chickquita.Application/Features/Coops/Queries/GetCoopByIdQueryHandler.cs
+++ b/backend/src/Chickquita.Application/Features/Coops/Queries/GetCoopByIdQueryHandler.cs
@@ -1,0 +1,82 @@
+using AutoMapper;
+using Chickquita.Domain.Common;
+using Chickquita.Application.DTOs;
+using Chickquita.Application.Interfaces;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Chickquita.Application.Features.Coops.Queries;
+
+public class GetCoopByIdQueryHandler : IRequestHandler<GetCoopByIdQuery, Result<CoopDto>>
+{
+    private readonly ICoopRepository _coopRepository;
+    private readonly ICurrentUserService _currentUserService;
+    private readonly IMapper _mapper;
+    private readonly ILogger<GetCoopByIdQueryHandler> _logger;
+
+    public GetCoopByIdQueryHandler(
+        ICoopRepository coopRepository,
+        ICurrentUserService currentUserService,
+        IMapper mapper,
+        ILogger<GetCoopByIdQueryHandler> logger)
+    {
+        _coopRepository = coopRepository;
+        _currentUserService = currentUserService;
+        _mapper = mapper;
+        _logger = logger;
+    }
+
+    public async Task<Result<CoopDto>> Handle(GetCoopByIdQuery request, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Processing GetCoopByIdQuery for coop {CoopId}", request.Id);
+
+        try
+        {
+            // Verify user is authenticated
+            if (!_currentUserService.IsAuthenticated)
+            {
+                _logger.LogWarning("GetCoopByIdQuery: User is not authenticated");
+                return Result<CoopDto>.Failure(Error.Unauthorized("User is not authenticated"));
+            }
+
+            // Get current tenant ID
+            var tenantId = _currentUserService.TenantId;
+            if (!tenantId.HasValue)
+            {
+                _logger.LogWarning("GetCoopByIdQuery: Tenant ID not found");
+                return Result<CoopDto>.Failure(Error.Unauthorized("Tenant not found"));
+            }
+
+            // Retrieve coop by ID (tenant isolation is handled by RLS and global query filter)
+            var coop = await _coopRepository.GetByIdAsync(request.Id);
+
+            if (coop == null)
+            {
+                _logger.LogInformation("Coop {CoopId} not found for tenant {TenantId}", request.Id, tenantId.Value);
+                return Result<CoopDto>.Failure(Error.NotFound("Coop not found"));
+            }
+
+            _logger.LogInformation(
+                "Successfully retrieved coop {CoopId} for tenant {TenantId}",
+                request.Id,
+                tenantId.Value);
+
+            var coopDto = _mapper.Map<CoopDto>(coop);
+
+            // Populate flocks count
+            coopDto.FlocksCount = await _coopRepository.GetFlocksCountAsync(coopDto.Id);
+
+            return Result<CoopDto>.Success(coopDto);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Error occurred while retrieving coop {CoopId}",
+                request.Id);
+
+            return Result<CoopDto>.Failure(
+                Error.Failure("An unexpected error occurred. Please try again."));
+        }
+    }
+}

--- a/backend/src/Chickquita.Application/Features/FlockHistory/Commands/UpdateFlockHistoryNotesCommand.cs
+++ b/backend/src/Chickquita.Application/Features/FlockHistory/Commands/UpdateFlockHistoryNotesCommand.cs
@@ -1,6 +1,4 @@
-using AutoMapper;
 using Chickquita.Application.DTOs;
-using Chickquita.Application.Interfaces;
 using Chickquita.Domain.Common;
 using FluentValidation;
 using MediatR;
@@ -39,67 +37,5 @@ public sealed class UpdateFlockHistoryNotesCommandValidator
             .MaximumLength(500)
             .When(x => x.Notes != null)
             .WithMessage("Notes cannot exceed 500 characters");
-    }
-}
-
-/// <summary>
-/// Handler for UpdateFlockHistoryNotesCommand.
-/// </summary>
-public sealed class UpdateFlockHistoryNotesCommandHandler
-    : IRequestHandler<UpdateFlockHistoryNotesCommand, Result<FlockHistoryDto>>
-{
-    private readonly IFlockHistoryRepository _repository;
-    private readonly IMapper _mapper;
-    private readonly IValidator<UpdateFlockHistoryNotesCommand> _validator;
-    private readonly IUnitOfWork _unitOfWork;
-
-    public UpdateFlockHistoryNotesCommandHandler(
-        IFlockHistoryRepository repository,
-        IMapper mapper,
-        IValidator<UpdateFlockHistoryNotesCommand> validator,
-        IUnitOfWork unitOfWork)
-    {
-        _repository = repository;
-        _mapper = mapper;
-        _validator = validator;
-        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
-    }
-
-    public async Task<Result<FlockHistoryDto>> Handle(
-        UpdateFlockHistoryNotesCommand request,
-        CancellationToken cancellationToken)
-    {
-        // Validate the command
-        var validationResult = await _validator.ValidateAsync(request, cancellationToken);
-        if (!validationResult.IsValid)
-        {
-            var errors = validationResult.Errors
-                .Select(e => e.ErrorMessage)
-                .ToList();
-
-            return Result<FlockHistoryDto>.Failure(
-                Error.Validation(string.Join("; ", errors)));
-        }
-
-        // Find the history entry (tenant isolation handled by RLS and global filters)
-        var historyEntry = await _repository.GetByIdAsync(request.HistoryId);
-
-        if (historyEntry == null)
-        {
-            return Result<FlockHistoryDto>.Failure(
-                Error.NotFound("Flock history entry not found"));
-        }
-
-        // Update the notes using the domain method
-        historyEntry.UpdateNotes(request.Notes);
-
-        // Save changes
-        await _repository.UpdateAsync(historyEntry);
-        await _unitOfWork.SaveChangesAsync(cancellationToken);
-
-        // Map to DTO and return
-        var dto = _mapper.Map<FlockHistoryDto>(historyEntry);
-
-        return Result<FlockHistoryDto>.Success(dto);
     }
 }

--- a/backend/src/Chickquita.Application/Features/FlockHistory/Commands/UpdateFlockHistoryNotesCommandHandler.cs
+++ b/backend/src/Chickquita.Application/Features/FlockHistory/Commands/UpdateFlockHistoryNotesCommandHandler.cs
@@ -1,0 +1,70 @@
+using AutoMapper;
+using Chickquita.Application.DTOs;
+using Chickquita.Application.Interfaces;
+using Chickquita.Domain.Common;
+using FluentValidation;
+using MediatR;
+
+namespace Chickquita.Application.Features.FlockHistory.Commands;
+
+/// <summary>
+/// Handler for UpdateFlockHistoryNotesCommand.
+/// </summary>
+public sealed class UpdateFlockHistoryNotesCommandHandler
+    : IRequestHandler<UpdateFlockHistoryNotesCommand, Result<FlockHistoryDto>>
+{
+    private readonly IFlockHistoryRepository _repository;
+    private readonly IMapper _mapper;
+    private readonly IValidator<UpdateFlockHistoryNotesCommand> _validator;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public UpdateFlockHistoryNotesCommandHandler(
+        IFlockHistoryRepository repository,
+        IMapper mapper,
+        IValidator<UpdateFlockHistoryNotesCommand> validator,
+        IUnitOfWork unitOfWork)
+    {
+        _repository = repository;
+        _mapper = mapper;
+        _validator = validator;
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+    }
+
+    public async Task<Result<FlockHistoryDto>> Handle(
+        UpdateFlockHistoryNotesCommand request,
+        CancellationToken cancellationToken)
+    {
+        // Validate the command
+        var validationResult = await _validator.ValidateAsync(request, cancellationToken);
+        if (!validationResult.IsValid)
+        {
+            var errors = validationResult.Errors
+                .Select(e => e.ErrorMessage)
+                .ToList();
+
+            return Result<FlockHistoryDto>.Failure(
+                Error.Validation(string.Join("; ", errors)));
+        }
+
+        // Find the history entry (tenant isolation handled by RLS and global filters)
+        var historyEntry = await _repository.GetByIdAsync(request.HistoryId);
+
+        if (historyEntry == null)
+        {
+            return Result<FlockHistoryDto>.Failure(
+                Error.NotFound("Flock history entry not found"));
+        }
+
+        // Update the notes using the domain method
+        historyEntry.UpdateNotes(request.Notes);
+
+        // Save changes
+        await _repository.UpdateAsync(historyEntry);
+        await _unitOfWork.SaveChangesAsync(cancellationToken);
+
+        // Map to DTO and return
+        var dto = _mapper.Map<FlockHistoryDto>(historyEntry);
+
+        return Result<FlockHistoryDto>.Success(dto);
+    }
+}

--- a/backend/src/Chickquita.Application/Features/Flocks/Queries/GetFlockHistoryQuery.cs
+++ b/backend/src/Chickquita.Application/Features/Flocks/Queries/GetFlockHistoryQuery.cs
@@ -1,6 +1,4 @@
-using AutoMapper;
 using Chickquita.Application.DTOs;
-using Chickquita.Application.Interfaces;
 using Chickquita.Domain.Common;
 using MediatR;
 
@@ -15,42 +13,4 @@ public sealed record GetFlockHistoryQuery : IRequest<Result<List<FlockHistoryDto
     /// The ID of the flock to get history for.
     /// </summary>
     public required Guid FlockId { get; init; }
-}
-
-/// <summary>
-/// Handler for GetFlockHistoryQuery.
-/// Returns all flock history entries sorted by change date (newest first).
-/// </summary>
-public sealed class GetFlockHistoryQueryHandler
-    : IRequestHandler<GetFlockHistoryQuery, Result<List<FlockHistoryDto>>>
-{
-    private readonly IFlockRepository _flockRepository;
-    private readonly IMapper _mapper;
-
-    public GetFlockHistoryQueryHandler(
-        IFlockRepository flockRepository,
-        IMapper mapper)
-    {
-        _flockRepository = flockRepository;
-        _mapper = mapper;
-    }
-
-    public async Task<Result<List<FlockHistoryDto>>> Handle(
-        GetFlockHistoryQuery request,
-        CancellationToken cancellationToken)
-    {
-        // Get the flock with its history (tenant isolation handled by RLS and global filters)
-        var flock = await _flockRepository.GetByIdAsync(request.FlockId);
-
-        if (flock == null)
-        {
-            return Result<List<FlockHistoryDto>>.Failure(
-                Error.NotFound("Flock not found"));
-        }
-
-        // Map history entries to DTOs (already sorted by ChangeDate DESC in repository)
-        var historyDtos = _mapper.Map<List<FlockHistoryDto>>(flock.History);
-
-        return Result<List<FlockHistoryDto>>.Success(historyDtos);
-    }
 }

--- a/backend/src/Chickquita.Application/Features/Flocks/Queries/GetFlockHistoryQueryHandler.cs
+++ b/backend/src/Chickquita.Application/Features/Flocks/Queries/GetFlockHistoryQueryHandler.cs
@@ -1,0 +1,45 @@
+using AutoMapper;
+using Chickquita.Application.DTOs;
+using Chickquita.Application.Interfaces;
+using Chickquita.Domain.Common;
+using MediatR;
+
+namespace Chickquita.Application.Features.Flocks.Queries;
+
+/// <summary>
+/// Handler for GetFlockHistoryQuery.
+/// Returns all flock history entries sorted by change date (newest first).
+/// </summary>
+public sealed class GetFlockHistoryQueryHandler
+    : IRequestHandler<GetFlockHistoryQuery, Result<List<FlockHistoryDto>>>
+{
+    private readonly IFlockRepository _flockRepository;
+    private readonly IMapper _mapper;
+
+    public GetFlockHistoryQueryHandler(
+        IFlockRepository flockRepository,
+        IMapper mapper)
+    {
+        _flockRepository = flockRepository;
+        _mapper = mapper;
+    }
+
+    public async Task<Result<List<FlockHistoryDto>>> Handle(
+        GetFlockHistoryQuery request,
+        CancellationToken cancellationToken)
+    {
+        // Get the flock with its history (tenant isolation handled by RLS and global filters)
+        var flock = await _flockRepository.GetByIdAsync(request.FlockId);
+
+        if (flock == null)
+        {
+            return Result<List<FlockHistoryDto>>.Failure(
+                Error.NotFound("Flock not found"));
+        }
+
+        // Map history entries to DTOs (already sorted by ChangeDate DESC in repository)
+        var historyDtos = _mapper.Map<List<FlockHistoryDto>>(flock.History);
+
+        return Result<List<FlockHistoryDto>>.Success(historyDtos);
+    }
+}

--- a/backend/src/Chickquita.Application/Features/Purchases/Queries/GetPurchaseByIdQuery.cs
+++ b/backend/src/Chickquita.Application/Features/Purchases/Queries/GetPurchaseByIdQuery.cs
@@ -1,9 +1,6 @@
-using AutoMapper;
 using Chickquita.Domain.Common;
 using Chickquita.Application.DTOs;
-using Chickquita.Application.Interfaces;
 using MediatR;
-using Microsoft.Extensions.Logging;
 
 namespace Chickquita.Application.Features.Purchases.Queries;
 
@@ -16,78 +13,4 @@ public sealed record GetPurchaseByIdQuery : IRequest<Result<PurchaseDto>>
     /// Gets or sets the purchase ID.
     /// </summary>
     public Guid Id { get; init; }
-}
-
-/// <summary>
-/// Handler for GetPurchaseByIdQuery that retrieves a single purchase.
-/// </summary>
-public sealed class GetPurchaseByIdQueryHandler : IRequestHandler<GetPurchaseByIdQuery, Result<PurchaseDto>>
-{
-    private readonly IPurchaseRepository _purchaseRepository;
-    private readonly ICurrentUserService _currentUserService;
-    private readonly IMapper _mapper;
-    private readonly ILogger<GetPurchaseByIdQueryHandler> _logger;
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="GetPurchaseByIdQueryHandler"/> class.
-    /// </summary>
-    /// <param name="purchaseRepository">The purchase repository.</param>
-    /// <param name="currentUserService">The current user service.</param>
-    /// <param name="mapper">The AutoMapper instance.</param>
-    /// <param name="logger">The logger instance.</param>
-    public GetPurchaseByIdQueryHandler(
-        IPurchaseRepository purchaseRepository,
-        ICurrentUserService currentUserService,
-        IMapper mapper,
-        ILogger<GetPurchaseByIdQueryHandler> logger)
-    {
-        _purchaseRepository = purchaseRepository;
-        _currentUserService = currentUserService;
-        _mapper = mapper;
-        _logger = logger;
-    }
-
-    /// <summary>
-    /// Handles the GetPurchaseByIdQuery by retrieving a single purchase.
-    /// </summary>
-    /// <param name="request">The get purchase by ID query.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>A result containing the purchase DTO or NOT_FOUND error.</returns>
-    public async Task<Result<PurchaseDto>> Handle(GetPurchaseByIdQuery request, CancellationToken cancellationToken)
-    {
-        _logger.LogInformation("Processing GetPurchaseByIdQuery for purchase {PurchaseId}", request.Id);
-
-        try
-        {
-            var tenantId = _currentUserService.TenantId;
-
-            // Retrieve purchase by ID (tenant isolation is handled by RLS and global query filter)
-            var purchase = await _purchaseRepository.GetByIdAsync(request.Id);
-
-            if (purchase == null)
-            {
-                _logger.LogInformation("Purchase {PurchaseId} not found for tenant {TenantId}", request.Id, tenantId.Value);
-                return Result<PurchaseDto>.Failure(Error.NotFound("Purchase not found"));
-            }
-
-            _logger.LogInformation(
-                "Successfully retrieved purchase {PurchaseId} for tenant {TenantId}",
-                request.Id,
-                tenantId.Value);
-
-            var purchaseDto = _mapper.Map<PurchaseDto>(purchase);
-
-            return Result<PurchaseDto>.Success(purchaseDto);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(
-                ex,
-                "Error occurred while retrieving purchase {PurchaseId}",
-                request.Id);
-
-            return Result<PurchaseDto>.Failure(
-                Error.Failure("An unexpected error occurred. Please try again."));
-        }
-    }
 }

--- a/backend/src/Chickquita.Application/Features/Purchases/Queries/GetPurchaseByIdQueryHandler.cs
+++ b/backend/src/Chickquita.Application/Features/Purchases/Queries/GetPurchaseByIdQueryHandler.cs
@@ -1,0 +1,82 @@
+using AutoMapper;
+using Chickquita.Domain.Common;
+using Chickquita.Application.DTOs;
+using Chickquita.Application.Interfaces;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Chickquita.Application.Features.Purchases.Queries;
+
+/// <summary>
+/// Handler for GetPurchaseByIdQuery that retrieves a single purchase.
+/// </summary>
+public sealed class GetPurchaseByIdQueryHandler : IRequestHandler<GetPurchaseByIdQuery, Result<PurchaseDto>>
+{
+    private readonly IPurchaseRepository _purchaseRepository;
+    private readonly ICurrentUserService _currentUserService;
+    private readonly IMapper _mapper;
+    private readonly ILogger<GetPurchaseByIdQueryHandler> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GetPurchaseByIdQueryHandler"/> class.
+    /// </summary>
+    /// <param name="purchaseRepository">The purchase repository.</param>
+    /// <param name="currentUserService">The current user service.</param>
+    /// <param name="mapper">The AutoMapper instance.</param>
+    /// <param name="logger">The logger instance.</param>
+    public GetPurchaseByIdQueryHandler(
+        IPurchaseRepository purchaseRepository,
+        ICurrentUserService currentUserService,
+        IMapper mapper,
+        ILogger<GetPurchaseByIdQueryHandler> logger)
+    {
+        _purchaseRepository = purchaseRepository;
+        _currentUserService = currentUserService;
+        _mapper = mapper;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Handles the GetPurchaseByIdQuery by retrieving a single purchase.
+    /// </summary>
+    /// <param name="request">The get purchase by ID query.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A result containing the purchase DTO or NOT_FOUND error.</returns>
+    public async Task<Result<PurchaseDto>> Handle(GetPurchaseByIdQuery request, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Processing GetPurchaseByIdQuery for purchase {PurchaseId}", request.Id);
+
+        try
+        {
+            var tenantId = _currentUserService.TenantId;
+
+            // Retrieve purchase by ID (tenant isolation is handled by RLS and global query filter)
+            var purchase = await _purchaseRepository.GetByIdAsync(request.Id);
+
+            if (purchase == null)
+            {
+                _logger.LogInformation("Purchase {PurchaseId} not found for tenant {TenantId}", request.Id, tenantId.Value);
+                return Result<PurchaseDto>.Failure(Error.NotFound("Purchase not found"));
+            }
+
+            _logger.LogInformation(
+                "Successfully retrieved purchase {PurchaseId} for tenant {TenantId}",
+                request.Id,
+                tenantId.Value);
+
+            var purchaseDto = _mapper.Map<PurchaseDto>(purchase);
+
+            return Result<PurchaseDto>.Success(purchaseDto);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Error occurred while retrieving purchase {PurchaseId}",
+                request.Id);
+
+            return Result<PurchaseDto>.Failure(
+                Error.Failure("An unexpected error occurred. Please try again."));
+        }
+    }
+}

--- a/backend/src/Chickquita.Application/Features/Purchases/Queries/GetPurchaseNamesQuery.cs
+++ b/backend/src/Chickquita.Application/Features/Purchases/Queries/GetPurchaseNamesQuery.cs
@@ -1,7 +1,5 @@
 using Chickquita.Domain.Common;
-using Chickquita.Application.Interfaces;
 using MediatR;
-using Microsoft.Extensions.Logging;
 
 namespace Chickquita.Application.Features.Purchases.Queries;
 
@@ -21,75 +19,4 @@ public sealed record GetPurchaseNamesQuery : IRequest<Result<List<string>>>
     /// Defaults to 20.
     /// </summary>
     public int Limit { get; init; } = 20;
-}
-
-/// <summary>
-/// Handler for GetPurchaseNamesQuery that retrieves distinct purchase names for autocomplete.
-/// </summary>
-public sealed class GetPurchaseNamesQueryHandler : IRequestHandler<GetPurchaseNamesQuery, Result<List<string>>>
-{
-    private readonly IPurchaseRepository _purchaseRepository;
-    private readonly ICurrentUserService _currentUserService;
-    private readonly ILogger<GetPurchaseNamesQueryHandler> _logger;
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="GetPurchaseNamesQueryHandler"/> class.
-    /// </summary>
-    /// <param name="purchaseRepository">The purchase repository.</param>
-    /// <param name="currentUserService">The current user service.</param>
-    /// <param name="logger">The logger instance.</param>
-    public GetPurchaseNamesQueryHandler(
-        IPurchaseRepository purchaseRepository,
-        ICurrentUserService currentUserService,
-        ILogger<GetPurchaseNamesQueryHandler> logger)
-    {
-        _purchaseRepository = purchaseRepository;
-        _currentUserService = currentUserService;
-        _logger = logger;
-    }
-
-    /// <summary>
-    /// Handles the GetPurchaseNamesQuery by retrieving filtered purchase names.
-    /// </summary>
-    /// <param name="request">The get purchase names query.</param>
-    /// <param name="cancellationToken">The cancellation token.</param>
-    /// <returns>A result containing the list of distinct purchase names.</returns>
-    public async Task<Result<List<string>>> Handle(GetPurchaseNamesQuery request, CancellationToken cancellationToken)
-    {
-        _logger.LogInformation(
-            "Processing GetPurchaseNamesQuery - Query: {Query}, Limit: {Limit}",
-            request.Query,
-            request.Limit);
-
-        try
-        {
-            var tenantId = _currentUserService.TenantId;
-
-            // Return empty list if query is null or empty
-            if (string.IsNullOrWhiteSpace(request.Query))
-            {
-                _logger.LogInformation("GetPurchaseNamesQuery: Query is empty, returning empty list");
-                return Result<List<string>>.Success(new List<string>());
-            }
-
-            // Retrieve distinct purchase names filtered by query (tenant isolation is handled by RLS and global query filter)
-            var names = await _purchaseRepository.GetDistinctNamesByQueryAsync(request.Query, request.Limit);
-
-            _logger.LogInformation(
-                "Retrieved {Count} distinct purchase names for tenant: {TenantId}",
-                names.Count,
-                tenantId.Value);
-
-            return Result<List<string>>.Success(names);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(
-                ex,
-                "Error occurred while retrieving purchase names");
-
-            return Result<List<string>>.Failure(
-                Error.Failure("An unexpected error occurred. Please try again."));
-        }
-    }
 }

--- a/backend/src/Chickquita.Application/Features/Purchases/Queries/GetPurchaseNamesQueryHandler.cs
+++ b/backend/src/Chickquita.Application/Features/Purchases/Queries/GetPurchaseNamesQueryHandler.cs
@@ -1,0 +1,77 @@
+using Chickquita.Domain.Common;
+using Chickquita.Application.Interfaces;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Chickquita.Application.Features.Purchases.Queries;
+
+/// <summary>
+/// Handler for GetPurchaseNamesQuery that retrieves distinct purchase names for autocomplete.
+/// </summary>
+public sealed class GetPurchaseNamesQueryHandler : IRequestHandler<GetPurchaseNamesQuery, Result<List<string>>>
+{
+    private readonly IPurchaseRepository _purchaseRepository;
+    private readonly ICurrentUserService _currentUserService;
+    private readonly ILogger<GetPurchaseNamesQueryHandler> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GetPurchaseNamesQueryHandler"/> class.
+    /// </summary>
+    /// <param name="purchaseRepository">The purchase repository.</param>
+    /// <param name="currentUserService">The current user service.</param>
+    /// <param name="logger">The logger instance.</param>
+    public GetPurchaseNamesQueryHandler(
+        IPurchaseRepository purchaseRepository,
+        ICurrentUserService currentUserService,
+        ILogger<GetPurchaseNamesQueryHandler> logger)
+    {
+        _purchaseRepository = purchaseRepository;
+        _currentUserService = currentUserService;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Handles the GetPurchaseNamesQuery by retrieving filtered purchase names.
+    /// </summary>
+    /// <param name="request">The get purchase names query.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A result containing the list of distinct purchase names.</returns>
+    public async Task<Result<List<string>>> Handle(GetPurchaseNamesQuery request, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation(
+            "Processing GetPurchaseNamesQuery - Query: {Query}, Limit: {Limit}",
+            request.Query,
+            request.Limit);
+
+        try
+        {
+            var tenantId = _currentUserService.TenantId;
+
+            // Return empty list if query is null or empty
+            if (string.IsNullOrWhiteSpace(request.Query))
+            {
+                _logger.LogInformation("GetPurchaseNamesQuery: Query is empty, returning empty list");
+                return Result<List<string>>.Success(new List<string>());
+            }
+
+            // Retrieve distinct purchase names filtered by query (tenant isolation is handled by RLS and global query filter)
+            var names = await _purchaseRepository.GetDistinctNamesByQueryAsync(request.Query, request.Limit);
+
+            _logger.LogInformation(
+                "Retrieved {Count} distinct purchase names for tenant: {TenantId}",
+                names.Count,
+                tenantId.Value);
+
+            return Result<List<string>>.Success(names);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Error occurred while retrieving purchase names");
+
+            return Result<List<string>>.Failure(
+                Error.Failure("An unexpected error occurred. Please try again."));
+        }
+    }
+}

--- a/backend/src/Chickquita.Application/Features/Users/Queries/GetCurrentUserQuery.cs
+++ b/backend/src/Chickquita.Application/Features/Users/Queries/GetCurrentUserQuery.cs
@@ -1,58 +1,7 @@
-using AutoMapper;
 using Chickquita.Domain.Common;
 using Chickquita.Application.DTOs;
-using Chickquita.Application.Interfaces;
 using MediatR;
-using Microsoft.Extensions.Logging;
 
 namespace Chickquita.Application.Features.Users.Queries;
 
 public record GetCurrentUserQuery : IRequest<Result<UserDto>>;
-
-public class GetCurrentUserQueryHandler : IRequestHandler<GetCurrentUserQuery, Result<UserDto>>
-{
-    private readonly ICurrentUserService _currentUserService;
-    private readonly ITenantRepository _tenantRepository;
-    private readonly IMapper _mapper;
-    private readonly ILogger<GetCurrentUserQueryHandler> _logger;
-
-    public GetCurrentUserQueryHandler(
-        ICurrentUserService currentUserService,
-        ITenantRepository tenantRepository,
-        IMapper mapper,
-        ILogger<GetCurrentUserQueryHandler> logger)
-    {
-        _currentUserService = currentUserService;
-        _tenantRepository = tenantRepository;
-        _mapper = mapper;
-        _logger = logger;
-    }
-
-    public async Task<Result<UserDto>> Handle(GetCurrentUserQuery request, CancellationToken cancellationToken)
-    {
-        if (!_currentUserService.IsAuthenticated)
-        {
-            _logger.LogWarning("Attempted to get current user for unauthenticated request");
-            return Result<UserDto>.Failure(Error.Unauthorized("User is not authenticated"));
-        }
-
-        var tenantId = _currentUserService.TenantId;
-        if (tenantId == null)
-        {
-            _logger.LogWarning("Authenticated user has no resolved tenant (missing org_id claim?)");
-            return Result<UserDto>.Failure(Error.Unauthorized("Tenant could not be determined"));
-        }
-
-        var tenant = await _tenantRepository.GetByIdAsync(tenantId.Value);
-
-        if (tenant == null)
-        {
-            _logger.LogWarning("No tenant found for tenant ID: {TenantId}", tenantId);
-            return Result<UserDto>.Failure(Error.NotFound("User not found"));
-        }
-
-        var userDto = _mapper.Map<UserDto>(tenant);
-        _logger.LogInformation("Successfully retrieved current user: {UserId}", userDto.Id);
-        return Result<UserDto>.Success(userDto);
-    }
-}

--- a/backend/src/Chickquita.Application/Features/Users/Queries/GetCurrentUserQueryHandler.cs
+++ b/backend/src/Chickquita.Application/Features/Users/Queries/GetCurrentUserQueryHandler.cs
@@ -1,0 +1,56 @@
+using AutoMapper;
+using Chickquita.Domain.Common;
+using Chickquita.Application.DTOs;
+using Chickquita.Application.Interfaces;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Chickquita.Application.Features.Users.Queries;
+
+public class GetCurrentUserQueryHandler : IRequestHandler<GetCurrentUserQuery, Result<UserDto>>
+{
+    private readonly ICurrentUserService _currentUserService;
+    private readonly ITenantRepository _tenantRepository;
+    private readonly IMapper _mapper;
+    private readonly ILogger<GetCurrentUserQueryHandler> _logger;
+
+    public GetCurrentUserQueryHandler(
+        ICurrentUserService currentUserService,
+        ITenantRepository tenantRepository,
+        IMapper mapper,
+        ILogger<GetCurrentUserQueryHandler> logger)
+    {
+        _currentUserService = currentUserService;
+        _tenantRepository = tenantRepository;
+        _mapper = mapper;
+        _logger = logger;
+    }
+
+    public async Task<Result<UserDto>> Handle(GetCurrentUserQuery request, CancellationToken cancellationToken)
+    {
+        if (!_currentUserService.IsAuthenticated)
+        {
+            _logger.LogWarning("Attempted to get current user for unauthenticated request");
+            return Result<UserDto>.Failure(Error.Unauthorized("User is not authenticated"));
+        }
+
+        var tenantId = _currentUserService.TenantId;
+        if (tenantId == null)
+        {
+            _logger.LogWarning("Authenticated user has no resolved tenant (missing org_id claim?)");
+            return Result<UserDto>.Failure(Error.Unauthorized("Tenant could not be determined"));
+        }
+
+        var tenant = await _tenantRepository.GetByIdAsync(tenantId.Value);
+
+        if (tenant == null)
+        {
+            _logger.LogWarning("No tenant found for tenant ID: {TenantId}", tenantId);
+            return Result<UserDto>.Failure(Error.NotFound("User not found"));
+        }
+
+        var userDto = _mapper.Map<UserDto>(tenant);
+        _logger.LogInformation("Successfully retrieved current user: {UserId}", userDto.Id);
+        return Result<UserDto>.Success(userDto);
+    }
+}


### PR DESCRIPTION
## Summary

- Split 6 combined Query+Handler (and Command+Handler) files into separate files, each containing a single class
- Applies the "always separate" (Option B) convention consistently across the codebase

## Changes

- `GetCoopByIdQuery.cs` — extracted handler to `GetCoopByIdQueryHandler.cs`
- `GetCurrentUserQuery.cs` — extracted handler to `GetCurrentUserQueryHandler.cs`
- `GetFlockHistoryQuery.cs` — extracted handler to `GetFlockHistoryQueryHandler.cs`
- `UpdateFlockHistoryNotesCommand.cs` — extracted handler to `UpdateFlockHistoryNotesCommandHandler.cs` (validator stays with command)
- `GetPurchaseByIdQuery.cs` — extracted handler to `GetPurchaseByIdQueryHandler.cs`
- `GetPurchaseNamesQuery.cs` — extracted handler to `GetPurchaseNamesQueryHandler.cs`

## Tests

No logic changes — pure file organization refactor. Existing tests continue to cover the same handler code.

Closes #103