### PR TITLE
fix: expose Reason property on UpdateFlockCompositionCommand to eliminate magic string

### DIFF
--- a/backend/src/Chickquita.Application/Features/Flocks/Commands/UpdateFlockCompositionCommand.cs
+++ b/backend/src/Chickquita.Application/Features/Flocks/Commands/UpdateFlockCompositionCommand.cs
@@ -6,7 +6,7 @@ namespace Chickquita.Application.Features.Flocks.Commands;
 
 /// <summary>
 /// Command to update flock composition (hens, roosters, chicks).
-/// Creates an immutable FlockHistory entry with reason "Manual update".
+/// Creates an immutable FlockHistory entry with the given reason.
 /// Use UpdateFlockCommand to update metadata (identifier, hatch date).
 /// </summary>
 public sealed record UpdateFlockCompositionCommand : IRequest<Result<FlockDto>>
@@ -30,6 +30,12 @@ public sealed record UpdateFlockCompositionCommand : IRequest<Result<FlockDto>>
     /// Gets or sets the new number of chicks.
     /// </summary>
     public int Chicks { get; init; }
+
+    /// <summary>
+    /// Gets or sets the reason for this composition change.
+    /// Defaults to "Manual update" when not specified.
+    /// </summary>
+    public string Reason { get; init; } = "Manual update";
 
     /// <summary>
     /// Gets or sets optional notes about this composition change.

--- a/backend/src/Chickquita.Application/Features/Flocks/Commands/UpdateFlockCompositionCommandHandler.cs
+++ b/backend/src/Chickquita.Application/Features/Flocks/Commands/UpdateFlockCompositionCommandHandler.cs
@@ -9,7 +9,7 @@ namespace Chickquita.Application.Features.Flocks.Commands;
 
 /// <summary>
 /// Handler for UpdateFlockCompositionCommand that updates flock composition.
-/// Creates an immutable FlockHistory entry with reason "Manual update".
+/// Creates an immutable FlockHistory entry with the reason supplied in the command.
 /// </summary>
 public sealed class UpdateFlockCompositionCommandHandler : IRequestHandler<UpdateFlockCompositionCommand, Result<FlockDto>>
 {
@@ -76,7 +76,7 @@ public sealed class UpdateFlockCompositionCommandHandler : IRequestHandler<Updat
                 hens: request.Hens,
                 roosters: request.Roosters,
                 chicks: request.Chicks,
-                reason: "Manual update",
+                reason: request.Reason,
                 notes: request.Notes);
 
             if (compositionResult.IsFailure)

--- a/backend/tests/Chickquita.Application.Tests/Features/Flocks/Commands/UpdateFlockCompositionCommandHandlerTests.cs
+++ b/backend/tests/Chickquita.Application.Tests/Features/Flocks/Commands/UpdateFlockCompositionCommandHandlerTests.cs
@@ -159,6 +159,100 @@ public class UpdateFlockCompositionCommandHandlerTests
     }
 
     [Fact]
+    public async Task Handle_WithCustomReason_ShouldUseProvidedReason()
+    {
+        // Arrange
+        var tenantId = Guid.NewGuid();
+        var coopId = Guid.NewGuid();
+        var flockId = Guid.NewGuid();
+
+        var command = new UpdateFlockCompositionCommand
+        {
+            FlockId = flockId,
+            Hens = 10,
+            Roosters = 2,
+            Chicks = 0,
+            Reason = "Mortality"
+        };
+
+        var existingFlock = Flock.Create(
+            tenantId,
+            coopId,
+            "Test Flock",
+            DateTime.UtcNow.AddDays(-30),
+            initialHens: 15,
+            initialRoosters: 3,
+            initialChicks: 0).Value;
+
+        Flock? capturedFlock = null;
+
+        _mockCurrentUserService.Setup(x => x.IsAuthenticated).Returns(true);
+        _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
+        _mockFlockRepository.Setup(x => x.GetByIdAsync(flockId)).ReturnsAsync(existingFlock);
+        _mockFlockRepository.Setup(x => x.UpdateAsync(It.IsAny<Flock>()))
+            .Callback<Flock>(f => capturedFlock = f)
+            .ReturnsAsync((Flock f) => f);
+        _mockMapper.Setup(x => x.Map<FlockDto>(It.IsAny<Flock>()))
+            .Returns(new FlockDto { Id = flockId });
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        capturedFlock.Should().NotBeNull();
+        var latestHistory = capturedFlock!.History.OrderByDescending(h => h.ChangeDate).First();
+        latestHistory.Reason.Should().Be("Mortality");
+    }
+
+    [Fact]
+    public async Task Handle_WithDefaultReason_ShouldUseManualUpdateFallback()
+    {
+        // Arrange
+        var tenantId = Guid.NewGuid();
+        var coopId = Guid.NewGuid();
+        var flockId = Guid.NewGuid();
+
+        var command = new UpdateFlockCompositionCommand
+        {
+            FlockId = flockId,
+            Hens = 10,
+            Roosters = 2,
+            Chicks = 0
+            // Reason not set — should default to "Manual update"
+        };
+
+        var existingFlock = Flock.Create(
+            tenantId,
+            coopId,
+            "Test Flock",
+            DateTime.UtcNow.AddDays(-30),
+            initialHens: 15,
+            initialRoosters: 3,
+            initialChicks: 0).Value;
+
+        Flock? capturedFlock = null;
+
+        _mockCurrentUserService.Setup(x => x.IsAuthenticated).Returns(true);
+        _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
+        _mockFlockRepository.Setup(x => x.GetByIdAsync(flockId)).ReturnsAsync(existingFlock);
+        _mockFlockRepository.Setup(x => x.UpdateAsync(It.IsAny<Flock>()))
+            .Callback<Flock>(f => capturedFlock = f)
+            .ReturnsAsync((Flock f) => f);
+        _mockMapper.Setup(x => x.Map<FlockDto>(It.IsAny<Flock>()))
+            .Returns(new FlockDto { Id = flockId });
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        capturedFlock.Should().NotBeNull();
+        var latestHistory = capturedFlock!.History.OrderByDescending(h => h.ChangeDate).First();
+        latestHistory.Reason.Should().Be("Manual update");
+    }
+
+    [Fact]
     public async Task Handle_WithZeroValues_ShouldUpdateSuccessfully()
     {
         // Arrange


### PR DESCRIPTION
## Summary

The `UpdateFlockCompositionCommandHandler` hardcoded `"Manual update"` as the `reason` argument when calling `flock.UpdateComposition()`. This meant API consumers had no way to record a meaningful reason for composition changes in the flock history.

## Changes

- `UpdateFlockCompositionCommand.cs` — added `Reason` property (`string`, defaults to `"Manual update"`) so existing clients remain unaffected
- `UpdateFlockCompositionCommandHandler.cs` — replaced hardcoded `reason: "Manual update"` with `reason: request.Reason`
- `UpdateFlockCompositionCommandHandlerTests.cs` — added two new tests:
  - `Handle_WithCustomReason_ShouldUseProvidedReason` — verifies a custom reason (e.g. `"Mortality"`) is persisted in flock history
  - `Handle_WithDefaultReason_ShouldUseManualUpdateFallback` — verifies the default reason `"Manual update"` is used when not specified

## Tests

Two new unit tests added covering the custom reason and default fallback paths. All existing tests continue to pass.

Closes #104