### PR TITLE
fix: rename dashboard widget labels from "This Week" to "Last 7 days"

### DIFF
--- a/frontend/src/locales/cs/translation.json
+++ b/frontend/src/locales/cs/translation.json
@@ -56,8 +56,8 @@
         "notAvailable": "Zatím nedostupné"
       },
       "weeklyProduction": {
-        "title": "Týdenní produkce",
-        "eggsThisWeek": "Vajec tento týden",
+        "title": "Posledních 7 dní",
+        "eggsThisWeek": "Vajec za 7 dní",
         "notAvailable": "Zatím nedostupné"
       },
       "flockStatus": {

--- a/frontend/src/locales/en/translation.json
+++ b/frontend/src/locales/en/translation.json
@@ -56,8 +56,8 @@
         "notAvailable": "Not available yet"
       },
       "weeklyProduction": {
-        "title": "Weekly Production",
-        "eggsThisWeek": "Eggs This Week",
+        "title": "Last 7 Days",
+        "eggsThisWeek": "Eggs (last 7 days)",
         "notAvailable": "Not available yet"
       },
       "flockStatus": {


### PR DESCRIPTION
Closes #142

## Summary

The dashboard widget was labeled "Týdenní produkce" / "Weekly Production" which implies a calendar week (Mon–Sun). The backend actually computes a rolling 7-day window (`today.AddDays(-6)`), causing user confusion.

## Changes

| File | Key | Before | After |
|------|-----|--------|-------|
| `cs/translation.json` | `weeklyProduction.title` | Týdenní produkce | Posledních 7 dní |
| `cs/translation.json` | `weeklyProduction.eggsThisWeek` | Vajec tento týden | Vajec za 7 dní |
| `en/translation.json` | `weeklyProduction.title` | Weekly Production | Last 7 Days |
| `en/translation.json` | `weeklyProduction.eggsThisWeek` | Eggs This Week | Eggs (last 7 days) |

No backend changes — the calculation was already correct.