### PR TITLE
test: add boundary tests for StatisticsRepository 7-day rolling window

### DIFF
--- a/backend/tests/Chickquita.Infrastructure.Tests/Repositories/StatisticsRepositoryTests.cs
+++ b/backend/tests/Chickquita.Infrastructure.Tests/Repositories/StatisticsRepositoryTests.cs
@@ -186,6 +186,34 @@ public class StatisticsRepositoryTests : IDisposable
         result.AvgEggsPerDay.Should().Be(50m / 7m);
     }
 
+    [Fact]
+    public async Task GetDashboardStatsAsync_RecordAtWindowBoundary_Included()
+    {
+        var today = DateTime.UtcNow.Date;
+        var boundary = today.AddDays(-6); // first day of 7-day window
+        var rec = DailyRecord.Create(_tenantId, _flockId, boundary, 10, null).Value;
+        _dbContext.DailyRecords.Add(rec);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _repository.GetDashboardStatsAsync();
+
+        result.ThisWeekEggs.Should().Be(10);
+    }
+
+    [Fact]
+    public async Task GetDashboardStatsAsync_RecordJustOutsideWindow_NotIncluded()
+    {
+        var today = DateTime.UtcNow.Date;
+        var outside = today.AddDays(-7); // one day before window starts
+        var rec = DailyRecord.Create(_tenantId, _flockId, outside, 10, null).Value;
+        _dbContext.DailyRecords.Add(rec);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _repository.GetDashboardStatsAsync();
+
+        result.ThisWeekEggs.Should().Be(0);
+    }
+
     #endregion
 
     #region GetDashboardStatsAsync — CostPerEgg


### PR DESCRIPTION
## Summary

Adds two missing boundary test cases for `GetDashboardStatsAsync` in `StatisticsRepositoryTests` to verify the rolling 7-day window edge cases are handled correctly.

## Changes

- `backend/tests/Chickquita.Infrastructure.Tests/Repositories/StatisticsRepositoryTests.cs` — added two new `[Fact]` test methods

## Tests

Two new tests added:
- `GetDashboardStatsAsync_RecordAtWindowBoundary_Included` — record at `today.AddDays(-6)` (first day of window) is counted in `ThisWeekEggs`
- `GetDashboardStatsAsync_RecordJustOutsideWindow_NotIncluded` — record at `today.AddDays(-7)` (one day before window) is **not** counted in `ThisWeekEggs`

Closes #143