### PR TITLE
test(backend): add comprehensive tests for revenue tracking settings

### DIFF
--- a/backend/tests/Chickquita.Api.Tests/Endpoints/SettingsEndpointsTests.cs
+++ b/backend/tests/Chickquita.Api.Tests/Endpoints/SettingsEndpointsTests.cs
@@ -1,0 +1,461 @@
+using System.Net;
+using System.Net.Http.Json;
+using Chickquita.Api.Endpoints;
+using Chickquita.Api.Tests.Helpers;
+using Chickquita.Application.DTOs;
+using Chickquita.Application.Interfaces;
+using Chickquita.Domain.Entities;
+using Chickquita.Infrastructure.Data;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace Chickquita.Api.Tests.Endpoints;
+
+/// <summary>
+/// Integration tests for Settings API endpoints.
+/// Tests full HTTP flow including authentication, tenant isolation, and business logic.
+/// </summary>
+public class SettingsEndpointsTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public SettingsEndpointsTests(WebApplicationFactory<Program> factory)
+    {
+        _factory = factory;
+    }
+
+    #region GET /api/settings Tests
+
+    [Fact]
+    public async Task GetTenantSettings_WithValidTenant_Returns200WithSettings()
+    {
+        // Arrange
+        var tenantId = Guid.NewGuid();
+        var mockCurrentUser = CreateMockCurrentUser("clerk_user_1", tenantId);
+
+        var factory = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                ReplaceWithInMemoryDatabase(services);
+                ReplaceCurrentUserService(services, mockCurrentUser);
+            });
+        });
+
+        using var scope = factory.Services.CreateScope();
+        await SeedTenant(scope, tenantId, "clerk_user_1");
+
+        var client = factory.CreateClient();
+
+        // Act
+        var response = await client.GetAsync("/api/settings");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<TenantSettingsDto>();
+        result.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task GetTenantSettings_WithDefaultTenant_ReturnsRevenueTrackingEnabledTrue()
+    {
+        // Arrange
+        var tenantId = Guid.NewGuid();
+        var mockCurrentUser = CreateMockCurrentUser("clerk_user_1", tenantId);
+
+        var factory = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                ReplaceWithInMemoryDatabase(services);
+                ReplaceCurrentUserService(services, mockCurrentUser);
+            });
+        });
+
+        using var scope = factory.Services.CreateScope();
+        await SeedTenant(scope, tenantId, "clerk_user_1");
+
+        var client = factory.CreateClient();
+
+        // Act
+        var response = await client.GetAsync("/api/settings");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<TenantSettingsDto>();
+        result.Should().NotBeNull();
+        result!.RevenueTrackingEnabled.Should().BeTrue();
+        result.Currency.Should().Be("CZK");
+    }
+
+    [Fact]
+    public async Task GetTenantSettings_WhenRevenueTrackingDisabled_ReturnsDisabledInResponse()
+    {
+        // Arrange
+        var tenantId = Guid.NewGuid();
+        var mockCurrentUser = CreateMockCurrentUser("clerk_user_1", tenantId);
+
+        var factory = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                ReplaceWithInMemoryDatabase(services);
+                ReplaceCurrentUserService(services, mockCurrentUser);
+            });
+        });
+
+        using var scope = factory.Services.CreateScope();
+        await SeedTenantWithSettings(scope, tenantId, "clerk_user_1", singleCoopMode: false, revenueTrackingEnabled: false, currency: "EUR");
+
+        var client = factory.CreateClient();
+
+        // Act
+        var response = await client.GetAsync("/api/settings");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<TenantSettingsDto>();
+        result.Should().NotBeNull();
+        result!.RevenueTrackingEnabled.Should().BeFalse();
+        result.Currency.Should().Be("EUR");
+    }
+
+    #endregion
+
+    #region PUT /api/settings Tests
+
+    [Fact]
+    public async Task UpdateTenantSettings_WithValidData_Returns204NoContent()
+    {
+        // Arrange
+        var tenantId = Guid.NewGuid();
+        var mockCurrentUser = CreateMockCurrentUser("clerk_user_1", tenantId);
+
+        var factory = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                ReplaceWithInMemoryDatabase(services);
+                ReplaceCurrentUserService(services, mockCurrentUser);
+            });
+        });
+
+        using var scope = factory.Services.CreateScope();
+        await SeedTenant(scope, tenantId, "clerk_user_1");
+
+        var client = factory.CreateClient();
+
+        var request = new UpdateTenantSettingsRequest(
+            SingleCoopMode: false,
+            RevenueTrackingEnabled: true,
+            Currency: "EUR");
+
+        // Act
+        var response = await client.PutAsJsonAsync("/api/settings", request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task UpdateTenantSettings_WithRevenueTrackingDisabled_PersistsDisabledState()
+    {
+        // Arrange
+        var tenantId = Guid.NewGuid();
+        var mockCurrentUser = CreateMockCurrentUser("clerk_user_1", tenantId);
+
+        var factory = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                ReplaceWithInMemoryDatabase(services);
+                ReplaceCurrentUserService(services, mockCurrentUser);
+            });
+        });
+
+        using var scope = factory.Services.CreateScope();
+        await SeedTenant(scope, tenantId, "clerk_user_1");
+
+        var client = factory.CreateClient();
+
+        var request = new UpdateTenantSettingsRequest(
+            SingleCoopMode: false,
+            RevenueTrackingEnabled: false,
+            Currency: "CZK");
+
+        // Act
+        var updateResponse = await client.PutAsJsonAsync("/api/settings", request);
+
+        // Assert — update succeeded
+        updateResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        // Assert — GET reflects the disabled state
+        var getResponse = await client.GetAsync("/api/settings");
+        getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await getResponse.Content.ReadFromJsonAsync<TenantSettingsDto>();
+        result.Should().NotBeNull();
+        result!.RevenueTrackingEnabled.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task UpdateTenantSettings_WithRevenueTrackingEnabled_PersistsEnabledState()
+    {
+        // Arrange — start with revenue tracking disabled
+        var tenantId = Guid.NewGuid();
+        var mockCurrentUser = CreateMockCurrentUser("clerk_user_1", tenantId);
+
+        var factory = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                ReplaceWithInMemoryDatabase(services);
+                ReplaceCurrentUserService(services, mockCurrentUser);
+            });
+        });
+
+        using var scope = factory.Services.CreateScope();
+        await SeedTenantWithSettings(scope, tenantId, "clerk_user_1", singleCoopMode: false, revenueTrackingEnabled: false, currency: "CZK");
+
+        var client = factory.CreateClient();
+
+        var request = new UpdateTenantSettingsRequest(
+            SingleCoopMode: false,
+            RevenueTrackingEnabled: true,
+            Currency: "CZK");
+
+        // Act
+        var updateResponse = await client.PutAsJsonAsync("/api/settings", request);
+
+        // Assert — update succeeded
+        updateResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        // Assert — GET reflects the enabled state
+        var getResponse = await client.GetAsync("/api/settings");
+        var result = await getResponse.Content.ReadFromJsonAsync<TenantSettingsDto>();
+        result.Should().NotBeNull();
+        result!.RevenueTrackingEnabled.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task UpdateTenantSettings_WithCurrencyChange_PersistsCurrency()
+    {
+        // Arrange
+        var tenantId = Guid.NewGuid();
+        var mockCurrentUser = CreateMockCurrentUser("clerk_user_1", tenantId);
+
+        var factory = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                ReplaceWithInMemoryDatabase(services);
+                ReplaceCurrentUserService(services, mockCurrentUser);
+            });
+        });
+
+        using var scope = factory.Services.CreateScope();
+        await SeedTenant(scope, tenantId, "clerk_user_1");
+
+        var client = factory.CreateClient();
+
+        var request = new UpdateTenantSettingsRequest(
+            SingleCoopMode: false,
+            RevenueTrackingEnabled: true,
+            Currency: "EUR");
+
+        // Act
+        await client.PutAsJsonAsync("/api/settings", request);
+
+        // Assert
+        var getResponse = await client.GetAsync("/api/settings");
+        var result = await getResponse.Content.ReadFromJsonAsync<TenantSettingsDto>();
+        result.Should().NotBeNull();
+        result!.Currency.Should().Be("EUR");
+    }
+
+    [Fact]
+    public async Task UpdateTenantSettings_WithNullCurrency_DefaultsToCZK()
+    {
+        // Arrange
+        var tenantId = Guid.NewGuid();
+        var mockCurrentUser = CreateMockCurrentUser("clerk_user_1", tenantId);
+
+        var factory = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                ReplaceWithInMemoryDatabase(services);
+                ReplaceCurrentUserService(services, mockCurrentUser);
+            });
+        });
+
+        using var scope = factory.Services.CreateScope();
+        await SeedTenant(scope, tenantId, "clerk_user_1");
+
+        var client = factory.CreateClient();
+
+        var request = new UpdateTenantSettingsRequest(
+            SingleCoopMode: false,
+            RevenueTrackingEnabled: true,
+            Currency: null);
+
+        // Act
+        await client.PutAsJsonAsync("/api/settings", request);
+
+        // Assert
+        var getResponse = await client.GetAsync("/api/settings");
+        var result = await getResponse.Content.ReadFromJsonAsync<TenantSettingsDto>();
+        result.Should().NotBeNull();
+        result!.Currency.Should().Be("CZK");
+    }
+
+    #endregion
+
+    #region Tenant Isolation Tests
+
+    [Fact]
+    public async Task GetTenantSettings_TenantIsolation_ReturnsOnlyOwnSettings()
+    {
+        // Arrange — two tenants in the same DB with different settings
+        var tenant1Id = Guid.NewGuid();
+        var tenant2Id = Guid.NewGuid();
+        var mockCurrentUser1 = CreateMockCurrentUser("clerk_user_1", tenant1Id);
+
+        // Use the same factory for both seeding and the client so they share the same SQLite connection
+        var factory = _factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                ReplaceWithInMemoryDatabase(services);
+                ReplaceCurrentUserService(services, mockCurrentUser1);
+            });
+        });
+
+        using var scope = factory.Services.CreateScope();
+        await SeedTenantWithSettings(scope, tenant1Id, "clerk_user_1", singleCoopMode: false, revenueTrackingEnabled: true, currency: "CZK");
+        await SeedTenantWithSettings(scope, tenant2Id, "clerk_user_2", singleCoopMode: true, revenueTrackingEnabled: false, currency: "EUR");
+
+        var client = factory.CreateClient();
+
+        // Act — authenticated as tenant1
+        var response = await client.GetAsync("/api/settings");
+
+        // Assert — returns only tenant1's settings, not tenant2's
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<TenantSettingsDto>();
+        result.Should().NotBeNull();
+        result!.RevenueTrackingEnabled.Should().BeTrue();
+        result.Currency.Should().Be("CZK");
+    }
+
+    #endregion
+
+    #region Endpoint Contract Tests
+
+    [Fact]
+    public void AllEndpoints_RequireAuthorization()
+    {
+        // Verify SettingsEndpoints.MapSettingsEndpoints exists and is properly structured
+        var mapMethod = typeof(SettingsEndpoints).GetMethod("MapSettingsEndpoints");
+        mapMethod.Should().NotBeNull("MapSettingsEndpoints method should exist");
+        mapMethod!.IsStatic.Should().BeTrue("MapSettingsEndpoints should be a static extension method");
+
+        var parameters = mapMethod.GetParameters();
+        parameters.Should().HaveCount(1, "MapSettingsEndpoints should have exactly one parameter");
+        parameters[0].ParameterType.Name.Should().Be("IEndpointRouteBuilder");
+    }
+
+    #endregion
+
+    // Helper methods
+    private static Mock<ICurrentUserService> CreateMockCurrentUser(string clerkUserId, Guid tenantId)
+    {
+        var mock = new Mock<ICurrentUserService>();
+        mock.Setup(x => x.ClerkUserId).Returns(clerkUserId);
+        mock.Setup(x => x.TenantId).Returns(tenantId);
+        mock.Setup(x => x.IsAuthenticated).Returns(true);
+        return mock;
+    }
+
+    private static void ReplaceWithInMemoryDatabase(IServiceCollection services)
+    {
+        var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(DbContextOptions<ApplicationDbContext>));
+        if (descriptor != null)
+        {
+            services.Remove(descriptor);
+        }
+
+        var connection = new SqliteConnection("DataSource=:memory:");
+        connection.Open();
+        services.AddSingleton(connection);
+
+        services.AddDbContext<ApplicationDbContext>((serviceProvider, options) =>
+        {
+            var conn = serviceProvider.GetRequiredService<SqliteConnection>();
+            options.UseSqlite(conn);
+            options.EnableSensitiveDataLogging();
+        });
+
+        var appContextDescriptors = services.Where(d => d.ServiceType == typeof(ApplicationDbContext)).ToList();
+        foreach (var d in appContextDescriptors) services.Remove(d);
+        services.AddScoped<ApplicationDbContext>(sp =>
+        {
+            var opts = sp.GetRequiredService<DbContextOptions<ApplicationDbContext>>();
+            var currentUser = sp.GetRequiredService<ICurrentUserService>();
+            return new SqliteApplicationDbContext(opts, currentUser);
+        });
+
+        services.AddAuthorization(options =>
+        {
+            options.DefaultPolicy = new AuthorizationPolicyBuilder()
+                .RequireAssertion(_ => true)
+                .Build();
+        });
+
+        services.AddTransient<IStartupFilter, DatabaseInitializerStartupFilter>();
+    }
+
+    private static void ReplaceCurrentUserService(IServiceCollection services, Mock<ICurrentUserService> mock)
+    {
+        var descriptor = services.SingleOrDefault(d => d.ServiceType == typeof(ICurrentUserService));
+        if (descriptor != null)
+        {
+            services.Remove(descriptor);
+        }
+
+        services.AddScoped(_ => mock.Object);
+    }
+
+    private static async Task SeedTenant(IServiceScope scope, Guid tenantId, string clerkUserId)
+    {
+        var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        await dbContext.Database.EnsureCreatedAsync();
+        var tenant = Tenant.Create(clerkUserId, $"{clerkUserId}@test.com").Value;
+        typeof(Tenant).GetProperty(nameof(Tenant.Id))!.SetValue(tenant, tenantId);
+        dbContext.Tenants.Add(tenant);
+        await dbContext.SaveChangesAsync();
+    }
+
+    private static async Task SeedTenantWithSettings(
+        IServiceScope scope,
+        Guid tenantId,
+        string clerkUserId,
+        bool singleCoopMode,
+        bool revenueTrackingEnabled,
+        string currency)
+    {
+        var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        await dbContext.Database.EnsureCreatedAsync();
+        var tenant = Tenant.Create(clerkUserId, $"{clerkUserId}@test.com").Value;
+        typeof(Tenant).GetProperty(nameof(Tenant.Id))!.SetValue(tenant, tenantId);
+        tenant.UpdateSettings(singleCoopMode: singleCoopMode, revenueTrackingEnabled: revenueTrackingEnabled, currency: currency);
+        dbContext.Tenants.Add(tenant);
+        await dbContext.SaveChangesAsync();
+    }
+}

--- a/backend/tests/Chickquita.Application.Tests/Features/Settings/Commands/UpdateTenantSettingsCommandHandlerTests.cs
+++ b/backend/tests/Chickquita.Application.Tests/Features/Settings/Commands/UpdateTenantSettingsCommandHandlerTests.cs
@@ -1,0 +1,214 @@
+using AutoFixture;
+using AutoFixture.AutoMoq;
+using Chickquita.Application.Features.Settings.Commands;
+using Chickquita.Application.Interfaces;
+using Chickquita.Domain.Entities;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Chickquita.Application.Tests.Features.Settings.Commands;
+
+/// <summary>
+/// Unit tests for UpdateTenantSettingsCommandHandler.
+/// Tests cover happy path, missing tenant, unauthorized access, and error handling.
+/// </summary>
+public class UpdateTenantSettingsCommandHandlerTests
+{
+    private readonly IFixture _fixture;
+    private readonly Mock<ITenantRepository> _mockTenantRepository;
+    private readonly Mock<ICurrentUserService> _mockCurrentUserService;
+    private readonly Mock<IUnitOfWork> _mockUnitOfWork;
+    private readonly Mock<ILogger<UpdateTenantSettingsCommandHandler>> _mockLogger;
+    private readonly UpdateTenantSettingsCommandHandler _handler;
+
+    public UpdateTenantSettingsCommandHandlerTests()
+    {
+        _fixture = new Fixture().Customize(new AutoMoqCustomization());
+
+        _mockTenantRepository = _fixture.Freeze<Mock<ITenantRepository>>();
+        _mockCurrentUserService = _fixture.Freeze<Mock<ICurrentUserService>>();
+        _mockUnitOfWork = _fixture.Freeze<Mock<IUnitOfWork>>();
+        _mockLogger = _fixture.Freeze<Mock<ILogger<UpdateTenantSettingsCommandHandler>>>();
+        _mockUnitOfWork.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(1);
+
+        _handler = new UpdateTenantSettingsCommandHandler(
+            _mockTenantRepository.Object,
+            _mockCurrentUserService.Object,
+            _mockUnitOfWork.Object,
+            _mockLogger.Object);
+    }
+
+    #region Happy Path Tests
+
+    [Fact]
+    public async Task Handle_WithValidCommand_ShouldUpdateSettingsSuccessfully()
+    {
+        // Arrange
+        var tenantId = Guid.NewGuid();
+        var tenant = Tenant.Create("org_abc", "Test Farm").Value;
+        typeof(Tenant).GetProperty(nameof(Tenant.Id))!.SetValue(tenant, tenantId);
+
+        _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
+        _mockTenantRepository.Setup(x => x.GetByIdAsync(tenantId)).ReturnsAsync(tenant);
+
+        var command = new UpdateTenantSettingsCommand
+        {
+            SingleCoopMode = false,
+            RevenueTrackingEnabled = true,
+            Currency = "EUR"
+        };
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeTrue();
+        tenant.RevenueTrackingEnabled.Should().BeTrue();
+        tenant.SingleCoopMode.Should().BeFalse();
+        tenant.Currency.Should().Be("EUR");
+
+        _mockTenantRepository.Verify(x => x.UpdateAsync(tenant), Times.Once);
+        _mockUnitOfWork.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WithRevenueTrackingDisabled_ShouldPersistDisabledState()
+    {
+        // Arrange
+        var tenantId = Guid.NewGuid();
+        var tenant = Tenant.Create("org_abc", "Test Farm").Value;
+        typeof(Tenant).GetProperty(nameof(Tenant.Id))!.SetValue(tenant, tenantId);
+
+        _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
+        _mockTenantRepository.Setup(x => x.GetByIdAsync(tenantId)).ReturnsAsync(tenant);
+
+        var command = new UpdateTenantSettingsCommand
+        {
+            SingleCoopMode = true,
+            RevenueTrackingEnabled = false,
+            Currency = "CZK"
+        };
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        tenant.RevenueTrackingEnabled.Should().BeFalse();
+
+        _mockUnitOfWork.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WithNullCurrency_ShouldDefaultToCZK()
+    {
+        // Arrange
+        var tenantId = Guid.NewGuid();
+        var tenant = Tenant.Create("org_abc", "Test Farm").Value;
+        typeof(Tenant).GetProperty(nameof(Tenant.Id))!.SetValue(tenant, tenantId);
+
+        _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
+        _mockTenantRepository.Setup(x => x.GetByIdAsync(tenantId)).ReturnsAsync(tenant);
+
+        var command = new UpdateTenantSettingsCommand
+        {
+            SingleCoopMode = false,
+            RevenueTrackingEnabled = true,
+            Currency = null
+        };
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        tenant.Currency.Should().Be("CZK");
+    }
+
+    #endregion
+
+    #region Authorization Tests
+
+    [Fact]
+    public async Task Handle_WhenTenantIdIsNull_ShouldReturnUnauthorizedError()
+    {
+        // Arrange
+        _mockCurrentUserService.Setup(x => x.TenantId).Returns((Guid?)null);
+
+        var command = new UpdateTenantSettingsCommand
+        {
+            SingleCoopMode = false,
+            RevenueTrackingEnabled = true
+        };
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Error.Unauthorized");
+
+        _mockTenantRepository.Verify(x => x.GetByIdAsync(It.IsAny<Guid>()), Times.Never);
+        _mockUnitOfWork.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    #endregion
+
+    #region Not Found Tests
+
+    [Fact]
+    public async Task Handle_WhenTenantNotFound_ShouldReturnNotFoundError()
+    {
+        // Arrange
+        var tenantId = Guid.NewGuid();
+        _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
+        _mockTenantRepository.Setup(x => x.GetByIdAsync(tenantId)).ReturnsAsync((Tenant?)null);
+
+        var command = new UpdateTenantSettingsCommand
+        {
+            SingleCoopMode = false,
+            RevenueTrackingEnabled = true
+        };
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Error.NotFound");
+
+        _mockUnitOfWork.Verify(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    #endregion
+
+    #region Error Handling Tests
+
+    [Fact]
+    public async Task Handle_WhenRepositoryThrowsException_ShouldReturnFailureError()
+    {
+        // Arrange
+        var tenantId = Guid.NewGuid();
+        _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
+        _mockTenantRepository.Setup(x => x.GetByIdAsync(tenantId))
+            .ThrowsAsync(new Exception("Database error"));
+
+        var command = new UpdateTenantSettingsCommand
+        {
+            SingleCoopMode = false,
+            RevenueTrackingEnabled = true
+        };
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Error.Failure");
+        result.Error.Message.Should().Be("An unexpected error occurred. Please try again.");
+    }
+
+    #endregion
+}

--- a/backend/tests/Chickquita.Application.Tests/Features/Settings/Queries/GetTenantSettingsQueryHandlerTests.cs
+++ b/backend/tests/Chickquita.Application.Tests/Features/Settings/Queries/GetTenantSettingsQueryHandlerTests.cs
@@ -1,0 +1,166 @@
+using AutoFixture;
+using AutoFixture.AutoMoq;
+using Chickquita.Application.DTOs;
+using Chickquita.Application.Features.Settings.Queries;
+using Chickquita.Application.Interfaces;
+using Chickquita.Domain.Entities;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Chickquita.Application.Tests.Features.Settings.Queries;
+
+/// <summary>
+/// Unit tests for GetTenantSettingsQueryHandler.
+/// Tests cover happy path, missing tenant, and unauthorized access.
+/// </summary>
+public class GetTenantSettingsQueryHandlerTests
+{
+    private readonly IFixture _fixture;
+    private readonly Mock<ITenantRepository> _mockTenantRepository;
+    private readonly Mock<ICurrentUserService> _mockCurrentUserService;
+    private readonly Mock<ILogger<GetTenantSettingsQueryHandler>> _mockLogger;
+    private readonly GetTenantSettingsQueryHandler _handler;
+
+    public GetTenantSettingsQueryHandlerTests()
+    {
+        _fixture = new Fixture().Customize(new AutoMoqCustomization());
+
+        _mockTenantRepository = _fixture.Freeze<Mock<ITenantRepository>>();
+        _mockCurrentUserService = _fixture.Freeze<Mock<ICurrentUserService>>();
+        _mockLogger = _fixture.Freeze<Mock<ILogger<GetTenantSettingsQueryHandler>>>();
+
+        _handler = new GetTenantSettingsQueryHandler(
+            _mockTenantRepository.Object,
+            _mockCurrentUserService.Object,
+            _mockLogger.Object);
+    }
+
+    #region Happy Path Tests
+
+    [Fact]
+    public async Task Handle_WithValidTenant_ShouldReturnSettings()
+    {
+        // Arrange
+        var tenantId = Guid.NewGuid();
+        var tenant = Tenant.Create("org_abc", "Test Farm").Value;
+        typeof(Tenant).GetProperty(nameof(Tenant.Id))!.SetValue(tenant, tenantId);
+
+        _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
+        _mockTenantRepository.Setup(x => x.GetByIdAsync(tenantId)).ReturnsAsync(tenant);
+
+        // Act
+        var result = await _handler.Handle(new GetTenantSettingsQuery(), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value.Should().BeOfType<TenantSettingsDto>();
+    }
+
+    [Fact]
+    public async Task Handle_WithDefaultTenant_ShouldReturnRevenueTrackingEnabledTrue()
+    {
+        // Arrange
+        var tenantId = Guid.NewGuid();
+        var tenant = Tenant.Create("org_abc", "Test Farm").Value;
+        typeof(Tenant).GetProperty(nameof(Tenant.Id))!.SetValue(tenant, tenantId);
+
+        _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
+        _mockTenantRepository.Setup(x => x.GetByIdAsync(tenantId)).ReturnsAsync(tenant);
+
+        // Act
+        var result = await _handler.Handle(new GetTenantSettingsQuery(), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.RevenueTrackingEnabled.Should().BeTrue();
+        result.Value.Currency.Should().Be("CZK");
+    }
+
+    [Fact]
+    public async Task Handle_WhenRevenueTrackingIsDisabled_ShouldReturnDisabledInDto()
+    {
+        // Arrange
+        var tenantId = Guid.NewGuid();
+        var tenant = Tenant.Create("org_abc", "Test Farm").Value;
+        typeof(Tenant).GetProperty(nameof(Tenant.Id))!.SetValue(tenant, tenantId);
+        tenant.UpdateSettings(singleCoopMode: false, revenueTrackingEnabled: false, currency: "EUR");
+
+        _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
+        _mockTenantRepository.Setup(x => x.GetByIdAsync(tenantId)).ReturnsAsync(tenant);
+
+        // Act
+        var result = await _handler.Handle(new GetTenantSettingsQuery(), CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.RevenueTrackingEnabled.Should().BeFalse();
+        result.Value.Currency.Should().Be("EUR");
+        result.Value.SingleCoopMode.Should().BeFalse();
+    }
+
+    #endregion
+
+    #region Authorization Tests
+
+    [Fact]
+    public async Task Handle_WhenTenantIdIsNull_ShouldReturnUnauthorizedError()
+    {
+        // Arrange
+        _mockCurrentUserService.Setup(x => x.TenantId).Returns((Guid?)null);
+
+        // Act
+        var result = await _handler.Handle(new GetTenantSettingsQuery(), CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Error.Unauthorized");
+
+        _mockTenantRepository.Verify(x => x.GetByIdAsync(It.IsAny<Guid>()), Times.Never);
+    }
+
+    #endregion
+
+    #region Not Found Tests
+
+    [Fact]
+    public async Task Handle_WhenTenantNotFound_ShouldReturnNotFoundError()
+    {
+        // Arrange
+        var tenantId = Guid.NewGuid();
+        _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
+        _mockTenantRepository.Setup(x => x.GetByIdAsync(tenantId)).ReturnsAsync((Tenant?)null);
+
+        // Act
+        var result = await _handler.Handle(new GetTenantSettingsQuery(), CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Error.NotFound");
+    }
+
+    #endregion
+
+    #region Error Handling Tests
+
+    [Fact]
+    public async Task Handle_WhenRepositoryThrowsException_ShouldReturnFailureError()
+    {
+        // Arrange
+        var tenantId = Guid.NewGuid();
+        _mockCurrentUserService.Setup(x => x.TenantId).Returns(tenantId);
+        _mockTenantRepository.Setup(x => x.GetByIdAsync(tenantId))
+            .ThrowsAsync(new Exception("Database error"));
+
+        // Act
+        var result = await _handler.Handle(new GetTenantSettingsQuery(), CancellationToken.None);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Code.Should().Be("Error.Failure");
+        result.Error.Message.Should().Be("An unexpected error occurred. Please try again.");
+    }
+
+    #endregion
+}

--- a/backend/tests/Chickquita.Domain.Tests/Entities/TenantTests.cs
+++ b/backend/tests/Chickquita.Domain.Tests/Entities/TenantTests.cs
@@ -103,4 +103,113 @@ public class TenantTests
         updateResult.IsFailure.Should().BeTrue();
         updateResult.Error.Message.Should().Contain("Name cannot be empty");
     }
+
+    #region UpdateSettings Tests
+
+    [Fact]
+    public void Create_ShouldHaveRevenueTrackingEnabledByDefault()
+    {
+        // Arrange & Act
+        var tenant = Tenant.Create(ValidOrgId, ValidName).Value;
+
+        // Assert
+        tenant.RevenueTrackingEnabled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void UpdateSettings_WithRevenueTrackingEnabled_ShouldPersist()
+    {
+        // Arrange
+        var tenant = Tenant.Create(ValidOrgId, ValidName).Value;
+        var originalUpdatedAt = tenant.UpdatedAt;
+        Thread.Sleep(10);
+
+        // Act
+        var result = tenant.UpdateSettings(singleCoopMode: false, revenueTrackingEnabled: true, currency: "CZK");
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        tenant.RevenueTrackingEnabled.Should().BeTrue();
+        tenant.UpdatedAt.Should().BeAfter(originalUpdatedAt);
+    }
+
+    [Fact]
+    public void UpdateSettings_WithRevenueTrackingDisabled_ShouldPersist()
+    {
+        // Arrange
+        var tenant = Tenant.Create(ValidOrgId, ValidName).Value;
+        var originalUpdatedAt = tenant.UpdatedAt;
+        Thread.Sleep(10);
+
+        // Act
+        var result = tenant.UpdateSettings(singleCoopMode: false, revenueTrackingEnabled: false, currency: "CZK");
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        tenant.RevenueTrackingEnabled.Should().BeFalse();
+        tenant.UpdatedAt.Should().BeAfter(originalUpdatedAt);
+    }
+
+    [Fact]
+    public void UpdateSettings_WithSingleCoopModeEnabled_ShouldPersist()
+    {
+        // Arrange
+        var tenant = Tenant.Create(ValidOrgId, ValidName).Value;
+
+        // Act
+        var result = tenant.UpdateSettings(singleCoopMode: true, revenueTrackingEnabled: true);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        tenant.SingleCoopMode.Should().BeTrue();
+    }
+
+    [Fact]
+    public void UpdateSettings_WithValidCurrency_ShouldNormalizeToUppercase()
+    {
+        // Arrange
+        var tenant = Tenant.Create(ValidOrgId, ValidName).Value;
+
+        // Act
+        var result = tenant.UpdateSettings(singleCoopMode: false, revenueTrackingEnabled: true, currency: "eur");
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        tenant.Currency.Should().Be("EUR");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void UpdateSettings_WithNullOrEmptyCurrency_ShouldDefaultToCZK(string? currency)
+    {
+        // Arrange
+        var tenant = Tenant.Create(ValidOrgId, ValidName).Value;
+
+        // Act
+        var result = tenant.UpdateSettings(singleCoopMode: false, revenueTrackingEnabled: true, currency: currency);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        tenant.Currency.Should().Be("CZK");
+    }
+
+    [Fact]
+    public void UpdateSettings_CanToggleRevenueTrackingMultipleTimes()
+    {
+        // Arrange
+        var tenant = Tenant.Create(ValidOrgId, ValidName).Value;
+        tenant.RevenueTrackingEnabled.Should().BeTrue(); // default
+
+        // Act & Assert — disable
+        tenant.UpdateSettings(singleCoopMode: false, revenueTrackingEnabled: false);
+        tenant.RevenueTrackingEnabled.Should().BeFalse();
+
+        // Act & Assert — re-enable
+        tenant.UpdateSettings(singleCoopMode: false, revenueTrackingEnabled: true);
+        tenant.RevenueTrackingEnabled.Should().BeTrue();
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary

Closes #161

The `revenueTrackingEnabled` feature was already fully implemented across both backend and frontend. This PR adds the missing test coverage at all three layers.

## Changes

**Domain tests** (`TenantTests.cs` extended):
- Default `RevenueTrackingEnabled` is `true` on `Tenant.Create`
- `UpdateSettings` correctly persists enabled/disabled state
- Currency normalization to uppercase
- Null/empty currency defaults to `CZK`
- `SingleCoopMode` toggle
- Can toggle `RevenueTrackingEnabled` multiple times

**Application tests** (new files):
- `GetTenantSettingsQueryHandlerTests`: happy path, defaults, disabled state, unauthorized (null TenantId), not found, repository exception
- `UpdateTenantSettingsCommandHandlerTests`: happy path, disabled state persisted, null currency defaults to `CZK`, unauthorized, not found, exception

**API integration tests** (`SettingsEndpointsTests.cs`):
- `GET /api/settings` returns 200 with correct defaults (`revenueTrackingEnabled: true`, `currency: CZK`)
- `GET /api/settings` reflects disabled revenue tracking after update
- `PUT /api/settings` returns 204 NoContent
- `PUT /api/settings` with `revenueTrackingEnabled: false` persists and is reflected on GET
- `PUT /api/settings` with `revenueTrackingEnabled: true` re-enables after disable
- `PUT /api/settings` persists currency changes
- `PUT /api/settings` with null currency defaults to `CZK`
- Tenant isolation: authenticated user only sees their own settings
- Endpoint authorization contract test

## Test plan

- [ ] All backend tests pass: `dotnet test`
- [ ] CI checks green